### PR TITLE
Omit "IP address" warning on rate limit exception

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
@@ -165,7 +165,9 @@ module Bosh::AwsCloud
       errors = [AWS::EC2::Errors::InvalidIPAddress::InUse, AWS::EC2::Errors::RequestLimitExceeded]
       Bosh::Common.retryable(sleep: instance_create_wait_time, tries: 20, on: errors) do |tries, error|
         @logger.info("Launching on demand instance...")
-        @logger.warn("IP address was in use: #{error}") if tries > 0
+        if error.class == AWS::EC2::Errors::InvalidIPAddress::InUse
+          @logger.warn("IP address was in use: #{error}")
+        end
         @region.instances.create(instance_params)
       end
     end

--- a/src/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
@@ -234,6 +234,7 @@ describe Bosh::AwsCloud::InstanceManager do
       expect(aws_instances).to receive(:create).with(aws_instance_params).and_raise(AWS::EC2::Errors::InvalidIPAddress::InUse)
       expect(aws_instances).to receive(:create).with(aws_instance_params).and_return(aws_instance)
       allow(Bosh::AwsCloud::ResourceWait).to receive(:for_instance).with(instance: aws_instance, state: :running)
+      expect(logger).to receive(:warn).with(/IP address was in use/).once
 
       allow(instance_manager).to receive(:instance_create_wait_time).and_return(0)
 
@@ -246,6 +247,7 @@ describe Bosh::AwsCloud::InstanceManager do
       expect(aws_instances).to receive(:create).with(aws_instance_params).and_raise(AWS::EC2::Errors::RequestLimitExceeded)
       expect(aws_instances).to receive(:create).with(aws_instance_params).and_return(aws_instance)
       allow(Bosh::AwsCloud::ResourceWait).to receive(:for_instance).with(instance: aws_instance, state: :running)
+      expect(logger).not_to receive(:warn).with(/IP address was in use/)
 
       allow(instance_manager).to receive(:instance_create_wait_time).and_return(0)
 


### PR DESCRIPTION
Instance creation was incorrectly logging a warning of "IP address was in
use" when the API request had failed due to rate limiting. This is because
2953c67 extended the existing `Bosh::Common.retryable` block without
changing the condition that warnings were logged on.

Fix this by only logging a warning if the exception indicates that the IP
address is invalid. We no longer need to check the number of tries, because
`error` is always `nil` on the first loop.

The tests feel slightly brittle and laboured in that they are matching the
existence and non-existence of some text. But it does seem like it's worth
testing for.