### PR TITLE
Use the default number of tries for creating snapshots

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/resource_wait.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/resource_wait.rb
@@ -103,7 +103,7 @@ module Bosh::AwsCloud
       valid_states = [:completed]
       validate_states(valid_states, target_state)
 
-      new.for_resource(resource: snapshot, target_state: target_state, tries: 18) do |current_state|
+      new.for_resource(resource: snapshot, target_state: target_state) do |current_state|
         current_state == target_state
       end
     end


### PR DESCRIPTION
Timeouts have been observed when uploading stemcells due to this
setting. Removing it will yield the same timeout setting as for the
other methods.