### PR TITLE
Add support for the property aws.max_retries for AWS Ruby SDK

### DIFF
--- a/jobs/aws_cpi/spec
+++ b/jobs/aws_cpi/spec
@@ -31,6 +31,9 @@ properties:
   aws.region:
     description: AWS region name
     example: us-east-1
+  aws.max_retries:
+    description: The maximum number of times AWS service errors and throttling errors should be retried. There is an exponential backoff in between retries, so the more retries the longer it can take to fail.
+    default: 2
 
   registry.username:
     description: User to access the Registry

--- a/jobs/aws_cpi/templates/cpi.json.erb
+++ b/jobs/aws_cpi/templates/cpi.json.erb
@@ -11,7 +11,8 @@ params = {
         "default_iam_instance_profile" => p('aws.default_iam_instance_profile', nil),
         "default_key_name" => p('aws.default_key_name'),
         "default_security_groups" => p('aws.default_security_groups'),
-        "region" => p('aws.region')
+        "region" => p('aws.region'),
+        "max_retries" => p('aws.max_retries')
       },
       "registry" => {
         "endpoint" => "http://#{p('registry.username')}:#{p('registry.password')}@#{p('registry.host')}:#{p('registry.port')}",

--- a/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -54,7 +54,8 @@ describe 'cpi.json.erb' do
             'default_iam_instance_profile' => nil,
             'default_key_name'=>'the_default_key_name',
             'default_security_groups'=>['security_group_1'],
-            'region'=>'moon'
+            'region'=>'moon',
+            'max_retries'=>2
           },
           'registry'=>{
             'endpoint'=>'http://admin:admin@registry_host.example.com:25777',


### PR DESCRIPTION
This covers part of the issue described in #19 

## What

This PR adds the property `aws.max_retries` to the spec and the `cpi.json`
template. This option is passed to the AWS Ruby SDK library:

http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/Core/Configuration.html#max_retries-instance_method

and it allows specify the maximum number of times AWS service errors (500) and
throttling errors should be retried. There is an exponential backoff in
between retries, so the more retries the longer it can take to fail.

Increasing this number would mitigate the errors caused Request Rate Limit from AWS. 

## Context

The option `aws.max_retries` [is already implemented in the CPI ruby code](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/blob/118ea6df1fd6c9f9c2116a5e47a27cfb33e834c9/src/bosh_aws_cpi/lib/cloud/aws/cloud.rb#L37), and passed to the ruby library.

In this PR:
 * We add the property in the job spec. Default value is 2, as [defined in the code](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/blob/118ea6df1fd6c9f9c2116a5e47a27cfb33e834c9/src/bosh_aws_cpi/lib/cloud/aws/cloud.rb#L9)
 * We add it to the template for `cpi.json`


## Notes
 * There will be other PR to https://github.com/cloudfoundry/docs-bosh to document this option.
 
 * Note, it is possible that using this option makes unnecessary to retry at the CPI level, implemented [here](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/blob/7e69657190a6b911ebd4d48259e32fe7b79d0e94/src/bosh_aws_cpi/lib/cloud/aws/resource_wait.rb#L179), [here](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/blob/eb9f26d419a5c94f5996fb82285fb29fc5515b89/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb#L166) or [here](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/blob/118ea6df1fd6c9f9c2116a5e47a27cfb33e834c9/src/bosh_aws_cpi/lib/cloud/aws/cloud.rb#L253).
  But analyse if it is required and remove that logic is out of the scope of this PR. Also, I consider that this PR should be merged and live for a while, and the users warned about the change of behaviour.

