### PR TITLE
Remove AWS RequestLimitExceded retries at the BOSH CPI Level

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud.rb
@@ -243,16 +243,15 @@ module Bosh::AwsCloud
         ensure_cb = Proc.new do |retries|
           cloud_error("Timed out waiting to delete volume `#{volume.id}'") if retries == tries
         end
-        errors = [AWS::EC2::Errors::VolumeInUse, AWS::EC2::Errors::RequestLimitExceeded]
+        error = AWS::EC2::Errors::VolumeInUse
 
-        Bosh::Common.retryable(tries: tries, sleep: sleep_cb, on: errors, ensure: ensure_cb) do
+        Bosh::Common.retryable(tries: tries, sleep: sleep_cb, on: error, ensure: ensure_cb) do
           begin
             volume.delete
           rescue AWS::EC2::Errors::InvalidVolume::NotFound => e
             logger.warn("Failed to delete disk '#{disk_id}' because it was not found: #{e.inspect}")
             raise Bosh::Clouds::DiskNotFound.new(false), "Disk '#{disk_id}' not found"
           end
-
           true # return true to only retry on Exceptions
         end
 
@@ -620,11 +619,7 @@ module Bosh::AwsCloud
       )
 
       Bosh::Common.retryable(
-        on: [
-          AWS::EC2::Errors::IncorrectState,
-          AWS::EC2::Errors::VolumeInUse,
-          AWS::EC2::Errors::RequestLimitExceeded
-        ],
+        on: [AWS::EC2::Errors::IncorrectState, AWS::EC2::Errors::VolumeInUse],
         sleep: sleep_cb,
         tries: tries
       ) do |retries, error|

--- a/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
@@ -163,8 +163,8 @@ module Bosh::AwsCloud
       # address is in use - it can happen when the director recreates a VM and AWS
       # is too slow to update its state when we have released the IP address and want to
       # realocate it again.
-      errors = [AWS::EC2::Errors::InvalidIPAddress::InUse, AWS::EC2::Errors::RequestLimitExceeded]
-      Bosh::Common.retryable(sleep: instance_create_wait_time, tries: 20, on: errors) do |tries, error|
+      errors = [AWS::EC2::Errors::InvalidIPAddress::InUse]
+      Bosh::Common.retryable(sleep: instance_create_wait_time, tries: 10, on: errors) do |tries, error|
         @logger.info("Launching on demand instance...")
         if error.class == AWS::EC2::Errors::InvalidIPAddress::InUse
           @logger.warn("IP address was in use: #{error}")

--- a/src/bosh_aws_cpi/lib/cloud/aws/resource_wait.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/resource_wait.rb
@@ -176,7 +176,6 @@ module Bosh::AwsCloud
         "Waiting for #{desc} to be #{target_state}",
         { interval: 2, total: tries, max: 32, exponential: true }
       )
-      errors << AWS::EC2::Errors::RequestLimitExceeded
       ensure_cb = Proc.new do |retries|
         cloud_error("Timed out waiting for #{desc} to be #{target_state}, took #{time_passed}s") if retries == tries
       end

--- a/src/bosh_aws_cpi/spec/unit/attach_disk_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/attach_disk_spec.rb
@@ -143,7 +143,7 @@ describe Bosh::AwsCloud::Cloud do
 
     before do
       allow(volume).to receive(:attach_to).
-          with(instance, '/dev/sdf').and_raise AWS::EC2::Errors::VolumeInUse
+          with(instance, '/dev/sdh').and_raise AWS::EC2::Errors::VolumeInUse
     end
 
     it 'retries default number of attempts' do
@@ -152,25 +152,7 @@ describe Bosh::AwsCloud::Cloud do
 
       expect {
         cloud.attach_disk('i-test', 'v-foobar')
-      }.to raise_error AWS::EC2::Errors::VolumeInUse
-    end
-  end
-
-  context 'when aws returns RequestLimitExceeded' do
-    before { allow(Kernel).to receive(:sleep) }
-
-    before do
-      allow(volume).to receive(:attach_to).
-          with(instance, '/dev/sdf').and_raise AWS::EC2::Errors::RequestLimitExceeded
-    end
-
-    it 'retries default wait attempts' do
-      expect(volume).to receive(:attach_to).exactly(
-          Bosh::AwsCloud::ResourceWait::DEFAULT_WAIT_ATTEMPTS).times
-
-      expect {
-        cloud.attach_disk('i-test', 'v-foobar')
-      }.to raise_error AWS::EC2::Errors::RequestLimitExceeded
+      }.to raise_error Bosh::Common::RetryCountExceeded
     end
   end
 end

--- a/src/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
@@ -241,19 +241,6 @@ describe Bosh::AwsCloud::InstanceManager do
       create_instance
     end
 
-    it 'retries creating the VM when the request limit is exceeded' do
-      allow(region).to receive(:subnets).and_return('sub-123456' => fake_aws_subnet)
-
-      expect(aws_instances).to receive(:create).with(aws_instance_params).and_raise(AWS::EC2::Errors::RequestLimitExceeded)
-      expect(aws_instances).to receive(:create).with(aws_instance_params).and_return(aws_instance)
-      allow(Bosh::AwsCloud::ResourceWait).to receive(:for_instance).with(instance: aws_instance, state: :running)
-      expect(logger).not_to receive(:warn).with(/IP address was in use/)
-
-      allow(instance_manager).to receive(:instance_create_wait_time).and_return(0)
-
-      create_instance
-    end
-
     context 'when waiting it to become running fails' do
       before { expect(instance).to receive(:wait_for_running).and_raise(create_err) }
       let(:create_err) { StandardError.new('fake-err') }


### PR DESCRIPTION
As per #23 and #19 the logic to retry when there is a RequestLimitExceded is in the client library code, so it is not needed at an upper level. 

This PR removes the logic added in several places to retry requests when the `RequestLimitExceded` exception is raised. Often this logic is related to other potential errors, so only the condition on this specific error has been removed.

I got special doubts about the file `resource_wait.rb`, which implements wrappers for several resources. `RequestLimitExceded` was the default error to retry, and after removing it, it left some of this resources with some retry logic which will not be ever activated. 

# Notes

 * if this PR is merged, it must be done after #23. 
 * It also includes de code from #23, so it might need rebasing. 
 * be aware that this will change the behaviour of the CPI as it stop retrying on  `RequestLimitExceded` unless the setting `max_retries` is not setup. This means that a lot of current users of the CPI will start to experience problems until they re-configure the CPI.
