### PR TITLE
Add AWS Asia Pacific (Seoul) Region

### DIFF
--- a/ci/assets/cloudformation-end2end.template.json
+++ b/ci/assets/cloudformation-end2end.template.json
@@ -51,6 +51,10 @@
         "EC2Principal": "ec2.amazonaws.com",
         "OpsWorksPrincipal": "opsworks.amazonaws.com"
       },
+      "ap-northeast-2": {
+        "EC2Principal": "ec2.amazonaws.com",
+        "OpsWorksPrincipal": "opsworks.amazonaws.com"
+      },
       "ap-southeast-2": {
         "EC2Principal": "ec2.amazonaws.com",
         "OpsWorksPrincipal": "opsworks.amazonaws.com"
@@ -78,6 +82,7 @@
       "ap-southeast-1" : { "AMI" : "ami-6aa38238" },
       "ap-southeast-2" : { "AMI" : "ami-893f53b3" },
       "ap-northeast-1" : { "AMI" : "ami-27d6e626" },
+      "ap-northeast-2" : { "AMI" : "ami-4118d72f" },
       "cn-north-1"     : { "AMI" : "ami-b23fad8b" }
     }
   },


### PR DESCRIPTION
AWS launched AWS Asia Pacific (Seoul) Region on January 6th, 2016. This PR adds support for it.