### PR TITLE
Encode registry password when rendering URI

### DIFF
--- a/jobs/aws_cpi/templates/cpi.json.erb
+++ b/jobs/aws_cpi/templates/cpi.json.erb
@@ -15,7 +15,7 @@ params = {
         "max_retries" => p('aws.max_retries')
       },
       "registry" => {
-        "endpoint" => "http://#{p('registry.username')}:#{p('registry.password')}@#{p('registry.host')}:#{p('registry.port')}",
+        "endpoint" => "http://#{p('registry.username')}:#{URI.escape(p('registry.password'), Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))}@#{p('registry.host')}:#{p('registry.port')}",
         "user" => p('registry.username'),
         "password" => p('registry.password')
       },

--- a/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -82,6 +82,18 @@ describe 'cpi.json.erb' do
     })
   end
 
+  context 'when the registry password includes special characters' do
+    special_chars_password = '=!@#$%^&*/-+?='
+    before do
+      manifest['properties']['registry']['password'] = special_chars_password
+    end
+
+    it 'encodes the password with special characters in the registry URL' do
+      registry_uri = URI(subject['cloud']['properties']['registry']['endpoint'])
+      expect(URI.decode(registry_uri.password)).to eq(special_chars_password)
+    end
+  end
+
   context 'when credentials are provided in aws properties' do
     before do
       manifest['properties']['aws'].merge!({


### PR DESCRIPTION
The registry password might include non valid characters and must be
encoded when rendering the registry endpoint.

This fixes https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/issues/18