### PR TITLE
Allow define security groups in resource_pool

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
@@ -130,7 +130,7 @@ module Bosh::AwsCloud
 
       set_user_data_parameter(instance_params, networks_spec)
       set_key_name_parameter(instance_params, resource_pool["key_name"], options["aws"]["default_key_name"])
-      set_security_groups_parameter(instance_params, networks_spec, options["aws"]["default_security_groups"])
+      set_security_groups_parameter(instance_params, resource_pool, networks_spec, options["aws"]["default_security_groups"])
       set_vpc_parameters(instance_params, networks_spec)
       set_iam_instance_profile_parameter(instance_params, resource_pool["iam_instance_profile"], options["aws"]["default_iam_instance_profile"])
       set_availability_zone_parameter(
@@ -275,8 +275,8 @@ module Bosh::AwsCloud
       instance_params[:key_name] = key_name unless key_name.nil?
     end
 
-    def set_security_groups_parameter(instance_params, networks_spec, default_security_groups)
-      security_groups = extract_security_groups(networks_spec)
+    def set_security_groups_parameter(instance_params, resource_pool, networks_spec, default_security_groups)
+      security_groups = resource_pool["security_groups"] || extract_security_groups(networks_spec)
       if security_groups.empty?
         validate_and_prepare_security_groups_parameter(instance_params, default_security_groups)
       else

--- a/src/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
@@ -992,9 +992,11 @@ describe Bosh::AwsCloud::InstanceManager do
         let(:sg_name_1) { 'yay' }
         let(:sg_name_2) { 'aya' }
         let(:sg_name_3) { 'default' }
+        let(:sg_name_4) { 'instance' }
         let(:sg_id_1) { 'sg-12345678' }
         let(:sg_id_2) { 'sg-23456789' }
         let(:sg_id_3) { 'sg-01234567' }
+        let(:sg_id_4) { 'sg-34567890' }
 
         let(:networks_spec) do
           {
@@ -1088,6 +1090,45 @@ describe Bosh::AwsCloud::InstanceManager do
             networks_spec['artwork']['cloud_properties']['security_groups'] = [sg_id_1, sg_id_2]
             instance_options['aws']['default_security_groups'] = [sg_id_3]
 
+            verify_error
+          end
+        end
+
+        context 'when resource_pool have security_groups configured' do
+          it "overrides network spec security groups names with instance security group names" do
+            networks_spec['network']['cloud_properties']['security_groups'] = sg_name_1
+            networks_spec['artwork']['cloud_properties']['security_groups'] = [sg_name_1, sg_name_2]
+            instance_options['aws']['default_security_groups'] = [sg_name_3]
+            resource_pool['security_groups'] = [sg_name_4]
+
+            verify_security_group_parameter(:security_groups, [sg_name_4])
+          end
+          it "overrides network spec security groups ids with instance security group names" do
+            networks_spec['network']['cloud_properties']['security_groups'] = sg_id_1
+            networks_spec['artwork']['cloud_properties']['security_groups'] = [sg_id_1, sg_id_2]
+            instance_options['aws']['default_security_groups'] = [sg_id_3]
+            resource_pool['security_groups'] = [sg_name_4]
+
+            verify_security_group_parameter(:security_groups, [sg_name_4])
+          end
+          it "overrides network spec security groups names with instance security group ids" do
+            networks_spec['network']['cloud_properties']['security_groups'] = sg_name_1
+            networks_spec['artwork']['cloud_properties']['security_groups'] = [sg_name_1, sg_name_2]
+            instance_options['aws']['default_security_groups'] = [sg_name_3]
+            resource_pool['security_groups'] = [sg_id_4]
+
+            verify_security_group_parameter(:security_group_ids, [sg_id_4])
+          end
+          it "overrides network spec security groups ids with instance security group ids" do
+            networks_spec['network']['cloud_properties']['security_groups'] = sg_id_1
+            networks_spec['artwork']['cloud_properties']['security_groups'] = [sg_id_1, sg_id_2]
+            instance_options['aws']['default_security_groups'] = [sg_id_3]
+            resource_pool['security_groups'] = [sg_id_4]
+
+            verify_security_group_parameter(:security_group_ids, [sg_id_4])
+          end
+          it 'raises an error when both ids and names are specified in security_groups' do
+            resource_pool['security_groups'] = [sg_id_4, sg_name_4]
             verify_error
           end
         end


### PR DESCRIPTION
Allows define security groups in the resource pool definition of an
instance.

The list of security groups will have precendence over the network specification
security group and default aws security group. I think that makes sense
as the user can rely on spiff/spruce to include the security groups from
a shared definition is required. Anyway, this point can be discussed

This fixes https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/issues/27

Note: If accepted, it requires update the documentation in https://github.com/cloudfoundry/docs-bosh/blob/master/aws-cpi.html.md.erb#L62