### PR TITLE
Add support for updating AWS routing table entries

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/instance.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/instance.rb
@@ -92,13 +92,7 @@ module Bosh::AwsCloud
           table = tables[definition["table_id"]]
           @logger.debug("Sending traffic for '#{definition["destination"]}' to '#{@aws_instance.id}' in '#{definition["table_id"]}'")
 
-          existing = false
-          table.routes.each do |route|
-              if definition["destination"] == route.destination_cidr_block
-                  existing = true
-              end
-          end
-          if existing
+          if table.routes.any? {|route| route.destination_cidr_block == definition["destination"] }
             table.replace_route(definition["destination"], { :instance => @aws_instance })
           else
             table.create_route(definition["destination"], { :instance => @aws_instance })

--- a/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
@@ -33,6 +33,7 @@ module Bosh::AwsCloud
         # attach to a load balancer, the instance must be running.
         instance.wait_for_running
         instance.attach_to_load_balancers(resource_pool['elbs'] || [])
+        instance.update_routing_tables(resource_pool['advertised_instance_routes'] || [])
       rescue => e
         @logger.warn("Failed to configure instance '#{instance.id}': #{e.inspect}")
         begin


### PR DESCRIPTION
The `advertised_instance_routes` cloud property on resource pools/vm
types has been added to allow manifests to connect routes on AWS
Routing Tables with specific instances, if you need to route traffic
through a BOSH deployed VM (like in the case of a site-to-site VPN).

If using this, it is recommended to only have a single instance of a
single job of that resource pool, to avoid confusion. If there are
multiple instances/jobs in the resource pool, the last one processed
will be the node assigned to the route.

Datastructure of `advertised_instance_routes` is as follows:

```
cloud_properties:
  advertised_instance_routes:
  - table_id:    rt-abcdef123
    destination: 10.0.0.0/16
  - table_id:    rt 12345abcd
    destination: 10.0.0.0/16
```

This allows the manifest to specify that multiple routing tables
are updated to send the destination route(s) to it. Once removed
from the manifest, the routes will remain, but once the VM is recreated,
the route will become a black hole in the AWS routing table, and cease
to work.