### PR TITLE
add the ability to set the network property 'source/destination check'

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/instance.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/instance.rb
@@ -25,6 +25,10 @@ module Bosh::AwsCloud
       @aws_instance.disassociate_elastic_ip
     end
 
+    def source_dest_check=(state)
+      @aws_instance.source_dest_check = state
+    end
+
     def wait_for_running
       # If we time out, it is because the instance never gets from state running to started,
       # so we signal the director that it is ok to retry the operation. At the moment this

--- a/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
@@ -34,7 +34,7 @@ module Bosh::AwsCloud
         instance.wait_for_running
         instance.attach_to_load_balancers(resource_pool['elbs'] || [])
         instance.update_routing_tables(resource_pool['advertised_routes'] || [])
-        instance.source_dest_check = resource_pool['source_dest_check'] || true
+        instance.source_dest_check = resource_pool.fetch('source_dest_check', true)
       rescue => e
         @logger.warn("Failed to configure instance '#{instance.id}': #{e.inspect}")
         begin

--- a/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
@@ -34,6 +34,7 @@ module Bosh::AwsCloud
         instance.wait_for_running
         instance.attach_to_load_balancers(resource_pool['elbs'] || [])
         instance.update_routing_tables(resource_pool['advertised_routes'] || [])
+        instance.source_dest_check = resource_pool['source_dest_check'] || true
       rescue => e
         @logger.warn("Failed to configure instance '#{instance.id}': #{e.inspect}")
         begin

--- a/src/bosh_aws_cpi/spec/spec_helper.rb
+++ b/src/bosh_aws_cpi/spec/spec_helper.rb
@@ -17,7 +17,8 @@ def mock_cloud_options
         'region' => 'us-east-1',
         'default_key_name' => 'sesame',
         'default_security_groups' => [],
-        'max_retries' => 8
+        'max_retries' => 8,
+        'source_dest_check' => false
       },
       'registry' => {
         'endpoint' => 'localhost:42288',

--- a/src/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
@@ -91,7 +91,7 @@ module Bosh::AwsCloud
       it 'should ask AWS to create an instance in the given region, with parameters built up from the given arguments' do
         instance_manager = InstanceManager.new(ec2, registry, elb, param_mapper, block_device_manager, logger)
         allow(instance_manager).to receive(:get_created_instance_id).with("run-instances-response").and_return('i-12345678')
-        allow(aws_instance).to receive(:source_dest_check=).with(true)
+        allow(aws_instance).to receive(:source_dest_check=).with(false)
 
         expect(aws_client).to receive(:run_instances).with({ fake: 'instance-params', min_count: 1, max_count: 1 }).and_return("run-instances-response")
         instance_manager.create(
@@ -238,7 +238,7 @@ module Bosh::AwsCloud
         expect(aws_client).to receive(:run_instances).with({ fake: 'instance-params', min_count: 1, max_count: 1 }).and_return("run-instances-response")
 
         allow(ResourceWait).to receive(:for_instance).with(instance: aws_instance, state: :running)
-        allow(aws_instance).to receive(:source_dest_check=).with(true)
+        allow(aws_instance).to receive(:source_dest_check=).with(false)
         expect(logger).to receive(:warn).with(/IP address was in use/).once
 
         instance_manager.create(

--- a/src/bosh_aws_cpi/spec/unit/instance_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/instance_spec.rb
@@ -168,6 +168,13 @@ module Bosh::AwsCloud
       end
     end
 
+    describe '#source_dest_check=' do
+      it 'propagates source_dest_check=' do
+        expect(aws_instance).to receive(:source_dest_check=).with(false)
+        instance.source_dest_check = false
+      end
+    end
+
     describe '#attach_to_load_balancers' do
       before { allow(elb).to receive(:load_balancers).and_return(load_balancers) }
       let(:load_balancers) { { 'fake-lb1-id' => load_balancer1, 'fake-lb2-id' => load_balancer2 } }

--- a/src/bosh_aws_cpi/spec/unit/instance_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/instance_spec.rb
@@ -169,9 +169,14 @@ module Bosh::AwsCloud
     end
 
     describe '#source_dest_check=' do
-      it 'propagates source_dest_check=' do
+      it 'propagates source_dest_check= true' do
         expect(aws_instance).to receive(:source_dest_check=).with(false)
         instance.source_dest_check = false
+      end
+
+      it 'propagates source_dest_check= false' do
+        expect(aws_instance).to receive(:source_dest_check=).with(true)
+        instance.source_dest_check = true
       end
     end
 


### PR DESCRIPTION
The ability to set the 'source/destination check' network property is useful for instances performing cross-VPC routing. This allows a resource pool property to set this, it defaults to 'true' which is the AWS default.

```
- name: my-vpn-server
  cloud_properties:
    source_dest_check: false
```