### PR TITLE
Test IPv6 static IP assignment

### DIFF
--- a/ci/tasks/run-integration.sh
+++ b/ci/tasks/run-integration.sh
@@ -33,6 +33,7 @@ export BOSH_AWS_LIFECYCLE_MANUAL_IP=$(echo ${metadata} | jq -e --raw-output ".Di
 export BOSH_AWS_ELB_ID=$(echo ${metadata} | jq -e --raw-output ".ELB")
 export BOSH_AWS_TARGET_GROUP_NAME=$(echo ${metadata} | jq -e --raw-output ".ALBTargetGroup")
 export BOSH_AWS_ELASTIC_IP=$(echo ${metadata} | jq -e --raw-output ".DeploymentEIP")
+export BOSH_AWS_IPV6_IP=$(echo ${metadata} | jq -e --raw-output ".StaticIPv6")
 
 export BOSH_CLI_SILENCE_SLOW_LOAD_WARNING=true
 


### PR DESCRIPTION
- Terraform generates IPv6 CIDR, address, propagates to
  integration test
- minor reformatting of Terraform template
- adjust instance type to t2.small; m3.medium does NOT work:
  `"IPv6 is not supported for the instance type 'm3.medium'"`