### PR TITLE
Add custom tags to snapshot volumes

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud.rb
@@ -351,13 +351,13 @@ module Bosh::AwsCloud
         snapshot = volume.create_snapshot(name.join('/'))
         logger.info("snapshot '#{snapshot.id}' of volume '#{disk_id}' created")
 
-
         tags = {}
         ['agent_id', 'instance_id', 'director_name', 'director_uuid'].each do |key|
           tags[key] = metadata[key]
         end
         tags['device'] = devices.first unless devices.empty?
         tags['Name'] = name.join('/')
+        tags.merge!(metadata['custom_tags']) if metadata['custom_tags']
         TagManager.tags(snapshot, tags)
 
         ResourceWait.for_snapshot(snapshot: snapshot, state: 'completed')

--- a/src/bosh_aws_cpi/spec/integration/manual_network_spec.rb
+++ b/src/bosh_aws_cpi/spec/integration/manual_network_spec.rb
@@ -27,7 +27,8 @@ describe Bosh::AwsCloud::Cloud do
   let(:eip)                               { ENV.fetch('BOSH_AWS_ELASTIC_IP') }
   let(:ipv6_ip)                           { ENV.fetch('BOSH_AWS_MANUAL_IPV6_IP') }
   let(:instance_type) { instance_type_with_ephemeral }
-  let(:vm_metadata) { { deployment: 'deployment', job: 'cpi_spec', index: '0', delete_me: 'please' } }
+  let(:custom_tags) { {custom1: 'custom_value1', custom2: 'custom_value2'} }
+  let(:vm_metadata) { { deployment: 'deployment', job: 'cpi_spec', index: '0', delete_me: 'please', custom_tags: custom_tags } }
   let(:disks) { [] }
   let(:network_spec) { {} }
   let(:vm_type) { { 'instance_type' => instance_type, 'availability_zone' => @subnet_zone } }
@@ -295,6 +296,8 @@ describe Bosh::AwsCloud::Cloud do
             expect(snapshot_tags['director_name']).to eq 'Director'
             expect(snapshot_tags['director_uuid']).to eq '6d06b0cc-2c08-43c5-95be-f1b2dd247e18'
             expect(snapshot_tags['Name']).to eq 'deployment/cpi_spec/0/sdf'
+            expect(snapshot_tags['custom1']).to eq 'custom_value1'
+            expect(snapshot_tags['custom2']).to eq 'custom_value2'
 
           ensure
             @cpi.delete_snapshot(snapshot_id) if snapshot_id

--- a/src/bosh_aws_cpi/spec/integration/manual_network_spec.rb
+++ b/src/bosh_aws_cpi/spec/integration/manual_network_spec.rb
@@ -27,8 +27,8 @@ describe Bosh::AwsCloud::Cloud do
   let(:eip)                               { ENV.fetch('BOSH_AWS_ELASTIC_IP') }
   let(:ipv6_ip)                           { ENV.fetch('BOSH_AWS_MANUAL_IPV6_IP') }
   let(:instance_type) { instance_type_with_ephemeral }
-  let(:custom_tags) { {custom1: 'custom_value1', custom2: 'custom_value2'} }
-  let(:vm_metadata) { { deployment: 'deployment', job: 'cpi_spec', index: '0', delete_me: 'please', custom_tags: custom_tags } }
+  let(:user_defined_tags) { {custom1: 'custom_value1', custom2: 'custom_value2'} }
+  let(:vm_metadata) { { deployment: 'deployment', job: 'cpi_spec', index: '0', delete_me: 'please'}.merge(user_defined_tags) }
   let(:disks) { [] }
   let(:network_spec) { {} }
   let(:vm_type) { { 'instance_type' => instance_type, 'availability_zone' => @subnet_zone } }
@@ -293,12 +293,17 @@ describe Bosh::AwsCloud::Cloud do
             expect(snapshot_tags['device']).to eq '/dev/sdf'
             expect(snapshot_tags['agent_id']).to eq 'agent'
             expect(snapshot_tags['instance_id']).to eq 'instance'
-            expect(snapshot_tags['director_name']).to eq 'Director'
+            expect(snapshot_tags['instance_name']).to eq 'cpi_spec/instance'
+            expect(snapshot_tags['instance_index']).to eq '0'
+            expect(snapshot_tags['director']).to eq 'Director'
             expect(snapshot_tags['director_uuid']).to eq '6d06b0cc-2c08-43c5-95be-f1b2dd247e18'
+            expect(snapshot_tags['deployment']).to eq 'deployment'
             expect(snapshot_tags['Name']).to eq 'deployment/cpi_spec/0/sdf'
             expect(snapshot_tags['custom1']).to eq 'custom_value1'
             expect(snapshot_tags['custom2']).to eq 'custom_value2'
-
+            expect(snapshot_tags['director_name']).to be_nil
+            expect(snapshot_tags['index']).to be_nil
+            expect(snapshot_tags['job']).to be_nil
           ensure
             @cpi.delete_snapshot(snapshot_id) if snapshot_id
             Bosh::Common.retryable(tries: 20, on: Bosh::Clouds::DiskNotAttached, sleep: lambda { |n, _| [2**(n-1), 30].min }) do

--- a/src/bosh_aws_cpi/spec/unit/snapshot_disk_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/snapshot_disk_spec.rb
@@ -28,8 +28,16 @@ describe Bosh::AwsCloud::Cloud do
       expect(Bosh::AwsCloud::ResourceWait).to receive(:for_snapshot).with(snapshot: snapshot, state: 'completed')
 
       expect(Bosh::AwsCloud::TagManager).to receive(:tags).with(snapshot,
-        { 'agent_id' => 'agent', 'instance_id' => 'instance', 'director_name' => 'Test Director',
-          'director_uuid' => '6d06b0cc-2c08-43c5-95be-f1b2dd247e18', 'device' => '/dev/sdf', 'Name' => 'deployment/job/0/sdf'
+        {
+          'agent_id' => 'agent',
+          'instance_id' => 'instance',
+          'director_uuid' => '6d06b0cc-2c08-43c5-95be-f1b2dd247e18',
+          'deployment'=> 'deployment',
+          'device' => '/dev/sdf',
+          'director' => 'Test Director',
+          'instance_index'=> '0',
+          'instance_name'=> 'job/instance',
+          'Name' => 'deployment/job/0/sdf'
         }
       )
 
@@ -58,8 +66,16 @@ describe Bosh::AwsCloud::Cloud do
 
 
       expect(Bosh::AwsCloud::TagManager).to receive(:tags).with(snapshot,
-        { 'agent_id' => 'agent', 'instance_id' => 'instance', 'director_name' => 'Test Director',
-          'director_uuid' => '6d06b0cc-2c08-43c5-95be-f1b2dd247e18', 'device' => '/dev/sdf', 'Name' => 'deployment/job/0/sdf'
+        {
+          'agent_id' => 'agent',
+          'instance_id' => 'instance',
+          'director_uuid' => '6d06b0cc-2c08-43c5-95be-f1b2dd247e18',
+          'deployment'=> 'deployment',
+          'device' => '/dev/sdf',
+          'director' => 'Test Director',
+          'instance_index'=> '0',
+          'instance_name'=> 'job/instance',
+          'Name' => 'deployment/job/0/sdf'
         }
       )
 
@@ -79,8 +95,16 @@ describe Bosh::AwsCloud::Cloud do
       )
 
       expect(Bosh::AwsCloud::TagManager).to receive(:tags).with(snapshot,
-        { 'agent_id' => 'agent', 'instance_id' => 'instance', 'director_name' => 'Test Director',
-          'director_uuid' => '6d06b0cc-2c08-43c5-95be-f1b2dd247e18', 'Name' => 'deployment/job/0'}
+        {
+          'agent_id' => 'agent',
+          'instance_id' => 'instance',
+          'director_uuid' => '6d06b0cc-2c08-43c5-95be-f1b2dd247e18',
+          'deployment'=> 'deployment',
+          'director' => 'Test Director',
+          'instance_index'=> '0',
+          'instance_name'=> 'job/instance',
+          'Name' => 'deployment/job/0'
+        }
       )
 
       cloud.snapshot_disk('vol-xxxxxxxx', metadata)

--- a/src/bosh_aws_cpi/spec/unit/snapshot_disk_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/snapshot_disk_spec.rb
@@ -36,6 +36,25 @@ describe Bosh::AwsCloud::Cloud do
       cloud.snapshot_disk('vol-xxxxxxxx', metadata)
     end
 
+    it 'merges provided custom tags when snapshotting' do
+      metadata['custom_tags'] = {'custom1' => 'tag1', 'custom2'=> 'tag2'}
+      cloud = mock_cloud do |ec2|
+        allow(ec2).to receive(:volume).with('vol-xxxxxxxx').and_return(volume)
+      end
+
+      allow(volume).to receive(:attachments).and_return([attachment])
+      allow(volume).to receive(:create_snapshot).with('deployment/job/0/sdf').and_return(snapshot)
+      allow(Bosh::AwsCloud::ResourceWait).to receive(:for_snapshot)
+
+      expect(Bosh::AwsCloud::TagManager).to receive(:tags).with(snapshot,
+                                                                { 'agent_id' => 'agent', 'instance_id' => 'instance', 'director_name' => 'Test Director',
+                                                                  'director_uuid' => '6d06b0cc-2c08-43c5-95be-f1b2dd247e18', 'device' => '/dev/sdf', 'Name' => 'deployment/job/0/sdf', 'custom1' => 'tag1', 'custom2'=> 'tag2'
+                                                                }
+      )
+
+      cloud.snapshot_disk('vol-xxxxxxxx', metadata)
+    end
+
     it 'handles string keys in metadata' do
       cloud = mock_cloud do |ec2|
         expect(ec2).to receive(:volume).with('vol-xxxxxxxx').and_return(volume)

--- a/src/bosh_aws_cpi/spec/unit/snapshot_disk_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/snapshot_disk_spec.rb
@@ -36,25 +36,6 @@ describe Bosh::AwsCloud::Cloud do
       cloud.snapshot_disk('vol-xxxxxxxx', metadata)
     end
 
-    it 'merges provided custom tags when snapshotting' do
-      metadata['custom_tags'] = {'custom1' => 'tag1', 'custom2'=> 'tag2'}
-      cloud = mock_cloud do |ec2|
-        allow(ec2).to receive(:volume).with('vol-xxxxxxxx').and_return(volume)
-      end
-
-      allow(volume).to receive(:attachments).and_return([attachment])
-      allow(volume).to receive(:create_snapshot).with('deployment/job/0/sdf').and_return(snapshot)
-      allow(Bosh::AwsCloud::ResourceWait).to receive(:for_snapshot)
-
-      expect(Bosh::AwsCloud::TagManager).to receive(:tags).with(snapshot,
-                                                                { 'agent_id' => 'agent', 'instance_id' => 'instance', 'director_name' => 'Test Director',
-                                                                  'director_uuid' => '6d06b0cc-2c08-43c5-95be-f1b2dd247e18', 'device' => '/dev/sdf', 'Name' => 'deployment/job/0/sdf', 'custom1' => 'tag1', 'custom2'=> 'tag2'
-                                                                }
-      )
-
-      cloud.snapshot_disk('vol-xxxxxxxx', metadata)
-    end
-
     it 'handles string keys in metadata' do
       cloud = mock_cloud do |ec2|
         expect(ec2).to receive(:volume).with('vol-xxxxxxxx').and_return(volume)


### PR DESCRIPTION
- custom tags are already added when creating volumes and
VMs, so this just makes snapshots consistent.

[#150754225](https://www.pivotaltracker.com/story/show/150754225)

Signed-off-by: Beyhan Veli <beyhan.veli@sap.com>