### PR TITLE
added cert file for bosh ca certs to initialization of elb client

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/aws_provider.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/aws_provider.rb
@@ -7,7 +7,7 @@ module Bosh::AwsCloud
     def initialize(aws_config, logger)
       @logger = logger
 
-      @elb_params = aws_params(aws_config, @logger)
+      @elb_params = elb_params(aws_config, @logger)
 
       @elb_client = Aws::ElasticLoadBalancing::Client.new(@elb_params)
       @alb_client = Aws::ElasticLoadBalancingV2::Client.new(@elb_params)
@@ -64,13 +64,10 @@ module Bosh::AwsCloud
 
     def elb_params(aws_config, logger)
       elb_params = {
-        credentials: aws_config.credentials,
-        retry_limit: aws_config.max_retries,
-        logger: logger,
-        log_level: :debug
         region: aws_config.region,
         credentials: aws_config.credentials,
-        logger: @logger
+        logger: logger,
+        log_level: :debug
       }
       elb_endpoint = aws_config.elb_endpoint
       if elb_endpoint

--- a/src/bosh_aws_cpi/lib/cloud/aws/aws_provider.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/aws_provider.rb
@@ -2,17 +2,18 @@ module Bosh::AwsCloud
   class AwsProvider
     include Helpers
 
-    attr_reader :ec2_client, :ec2_resource, :alb_client, :elb_client
+    attr_reader :ec2_client, :ec2_resource, :alb_client, :elb_client, :elb_params, :ec2_params
 
     def initialize(aws_config, logger)
+      @aws_config = aws_config
       @logger = logger
 
-      @elb_params = elb_params(aws_config, @logger)
+      @elb_params = initialize_params(@aws_config.elb_endpoint)
 
       @elb_client = Aws::ElasticLoadBalancing::Client.new(@elb_params)
       @alb_client = Aws::ElasticLoadBalancingV2::Client.new(@elb_params)
 
-      @aws_params = aws_params(aws_config, @logger)
+      @ec2_params = initialize_params(@aws_config.ec2_endpoint)
 
       # AWS Ruby SDK is threadsafe but Ruby autoload isn't,
       # so we need to trigger eager autoload while constructing CPI
@@ -20,7 +21,7 @@ module Bosh::AwsCloud
 
       # In SDK v2 the default is more request driven, while the old 'model way' lives in Resource.
       # Therefore in most cases Aws::EC2::Resource would replace the client.
-      @ec2_client = Aws::EC2::Client.new(@aws_params)
+      @ec2_client = Aws::EC2::Client.new(@ec2_params)
       @ec2_resource = Aws::EC2::Resource.new(client: @ec2_client)
     end
 
@@ -62,53 +63,27 @@ module Bosh::AwsCloud
 
     private
 
-    def elb_params(aws_config, logger)
-      elb_params = {
-        region: aws_config.region,
-        credentials: aws_config.credentials,
-        logger: logger,
+    def initialize_params(endpoint)
+      params = {
+        credentials: @aws_config.credentials,
+        retry_limit: @aws_config.max_retries,
+        logger: @logger,
         log_level: :debug
       }
-      elb_endpoint = aws_config.elb_endpoint
-      if elb_endpoint
-        if URI(aws_config.elb_endpoint).scheme.nil?
-          elb_endpoint = "https://#{elb_endpoint}"
-        end
-        elb_params[:endpoint] = elb_endpoint
+      if @aws_config.region
+        params[:region] = @aws_config.region
       end
-
-      if ENV.has_key?('BOSH_CA_CERT_FILE')
-        elb_params[:ssl_ca_bundle] = ENV['BOSH_CA_CERT_FILE']
-      end
-
-      elb_params
-    end
-
-    def aws_params(aws_config, logger)
-      aws_params = {
-        credentials: aws_config.credentials,
-        retry_limit: aws_config.max_retries,
-        logger: logger,
-        log_level: :debug
-      }
-
-      if aws_config.region
-        aws_params[:region] = aws_config.region
-      end
-      if aws_config.ec2_endpoint
-        endpoint = aws_config.ec2_endpoint
-        if URI(aws_config.ec2_endpoint).scheme.nil?
+      if endpoint
+        if URI(endpoint).scheme.nil?
           endpoint = "https://#{endpoint}"
         end
-        aws_params[:endpoint] = endpoint
+        params[:endpoint] = endpoint
       end
 
-      # TODO(cdutra): move this to a better place
       if ENV.has_key?('BOSH_CA_CERT_FILE')
-        aws_params[:ssl_ca_bundle] = ENV['BOSH_CA_CERT_FILE']
+        params[:ssl_ca_bundle] = ENV['BOSH_CA_CERT_FILE']
       end
-
-      aws_params
+      params
     end
   end
 end

--- a/src/bosh_aws_cpi/spec/unit/aws_provider_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/aws_provider_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+
+describe Bosh::AwsCloud::AwsProvider do
+
+  let(:options) do
+    opts = mock_cloud_options['properties']
+    opts
+  end
+  let(:logger) { Bosh::Clouds::Config.logger}
+  let(:config) { Bosh::AwsCloud::Config.build(options.dup.freeze) }
+  let(:provider) { Bosh::AwsCloud::AwsProvider.new(config.aws, logger) }
+
+  it 'should configure elb_params' do
+    params = provider.elb_params
+    expect(params[:region]).to eq('us-east-1')
+    expect(params[:endpoint]).to eq(nil)
+    expect(params[:ssl_ca_bundle]).to eq(nil)
+    expect(params[:retry_limit]).to eq(8)
+    expect(params[:log_level]).to eq(:debug)
+  end
+
+  it 'should configure ec2_params' do
+    params = provider.ec2_params
+    expect(params[:region]).to eq('us-east-1')
+    expect(params[:endpoint]).to eq(nil)
+    expect(params[:ssl_ca_bundle]).to eq(nil)
+    expect(params[:retry_limit]).to eq(8)
+    expect(params[:logger]).to be_truthy
+    expect(params[:log_level]).to eq(:debug)
+  end
+
+  context 'no region is set' do
+    let(:options) do
+      opts = mock_cloud_options['properties']
+      opts['aws'].delete('region')
+      opts['aws'].store("ec2_endpoint", "http://the_ec2_endpoint.com")
+      opts['aws'].store("elb_endpoint", "http://the_elb_endpoint.com")
+      opts
+    end
+
+    it 'should configure elb_params' do
+      params = provider.elb_params
+      expect(params[:region]).to eq(nil)
+    end
+
+    it 'should configure ec2_params' do
+      params = provider.ec2_params
+      expect(params[:region]).to eq(nil)
+    end
+  end
+
+  context 'endpoints are set with protocol' do
+    let(:options) do
+      opts = mock_cloud_options['properties']
+      opts['aws'].store("ec2_endpoint", "http://the_ec2_endpoint.com")
+      opts['aws'].store("elb_endpoint", "http://the_elb_endpoint.com")
+      opts
+    end
+
+    it 'should configure elb_params' do
+      params = provider.elb_params
+      expect(params[:endpoint]).to eq("http://the_elb_endpoint.com")
+    end
+
+    it 'should configure ec2_params' do
+      params = provider.ec2_params
+      expect(params[:endpoint]).to eq("http://the_ec2_endpoint.com")
+    end
+  end
+
+  context 'endpoints have no protocol' do
+    let(:options) do
+      opts = mock_cloud_options['properties']
+      opts['aws'].store("ec2_endpoint", "the_ec2_endpoint.com")
+      opts['aws'].store("elb_endpoint", "the_elb_endpoint.com")
+      opts
+    end
+
+    it 'should configure elb_params' do
+      params = provider.elb_params
+      expect(params[:endpoint]).to eq("https://the_elb_endpoint.com")
+    end
+
+    it 'should configure ec2_params' do
+      params = provider.ec2_params
+      expect(params[:endpoint]).to eq("https://the_ec2_endpoint.com")
+    end
+  end
+
+  context 'bosh ca cert file is set' do
+    before do
+      ENV['BOSH_CA_CERT_FILE'] = "/some/path/file.pem"
+    end
+
+    after do
+      ENV.delete('BOSH_CA_CERT_FILE')
+    end
+    it 'should configure elb_params' do
+      params = provider.elb_params
+      expect(params[:ssl_ca_bundle]).to eq('/some/path/file.pem')
+    end
+
+    it 'should configure ec2_params' do
+      params = provider.ec2_params
+      expect(params[:ssl_ca_bundle]).to eq('/some/path/file.pem')
+    end
+  end
+end


### PR DESCRIPTION
This addresses issue - https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/issues/65 for setup where elb endpoint is signed by custom ssl cert