### PR TITLE
Implement support for static STS credentials

### DIFF
--- a/ci/assets/terraform/template.tf
+++ b/ci/assets/terraform/template.tf
@@ -1,5 +1,8 @@
 variable "access_key" {}
 variable "secret_key" {}
+variable "session_token" {
+  default = ""
+}
 variable "region" {}
 variable "env_name" {}
 variable "public_key" {}
@@ -7,6 +10,7 @@ variable "public_key" {}
 provider "aws" {
   access_key = "${var.access_key}"
   secret_key = "${var.secret_key}"
+  token = "${var.session_token}"
   region = "${var.region}"
 }
 

--- a/ci/tasks/run-integration.sh
+++ b/ci/tasks/run-integration.sh
@@ -22,6 +22,9 @@ metadata=$(cat ${METADATA_FILE})
 
 export BOSH_AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
 export BOSH_AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+if [ "${AWS_SESSION_TOKEN}" ]; then
+	export BOSH_AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+fi
 export BOSH_AWS_DEFAULT_KEY_NAME=$(echo ${metadata} | jq -e --raw-output ".default_key_name")
 export BOSH_AWS_REGION=$(echo ${metadata} | jq -e --raw-output ".region")
 export BOSH_AWS_SUBNET_ID=$(echo ${metadata} | jq -e --raw-output ".subnet_id")

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,7 +34,10 @@ of it on your local system.
   ```bash
   export AWS_ACCESS_KEY_ID=AKIAINSxxxxxxxxxxxxx
   export AWS_SECRET_ACCESS_KEY=LvgQOmCtjL1yhcxxxxxxxxxxxxxxxxxxxxxxxxxx
-  # optional
+  # Optionally use STS Tokens
+  # export AWS_SESSION_TOKEN=xxxxxxxx
+
+  # Optionally use alternate region
   # export AWS_DEFAULT_REGION=us-west-1
   ```
 1. source your `lifecycle.env` file

--- a/jobs/aws_cpi/spec
+++ b/jobs/aws_cpi/spec
@@ -20,6 +20,9 @@ properties:
   aws.secret_access_key:
     description: AWS secret_access_key for the aws cpi (Required when aws.credentials_source is set to `static`)
     default: null
+  aws.session_token:
+    description: AWS session_token when using STS credentials for the aws cpi (Optional, used when aws.credentials_source is set to `static`)
+    default: null
   aws.default_iam_instance_profile:
     description: Default AWS iam_instance_profile for the aws cpi
     default: null

--- a/jobs/aws_cpi/templates/cpi.json.erb
+++ b/jobs/aws_cpi/templates/cpi.json.erb
@@ -8,6 +8,7 @@ params = {
         "credentials_source" => p('aws.credentials_source'),
         "access_key_id" => p('aws.access_key_id', nil),
         "secret_access_key" => p('aws.secret_access_key', nil),
+        "session_token" => p('aws.session_token', nil),
         "default_iam_instance_profile" => p('aws.default_iam_instance_profile', nil),
         "default_key_name" => p('aws.default_key_name'),
         "default_security_groups" => p('aws.default_security_groups'),
@@ -60,6 +61,7 @@ if_p('blobstore') do
       "credentials_source" => p(['agent.blobstore.credentials_source', 'blobstore.credentials_source']),
       "access_key_id" => p(['agent.blobstore.access_key_id', 'blobstore.access_key_id'], nil),
       "secret_access_key" => p(['agent.blobstore.secret_access_key', 'blobstore.secret_access_key'], nil),
+      "session_token" => p(['agent.blobstore.session_token', 'blobstore.session_token'], nil),
     }
 
     def update_blobstore_options(blobstore, manifest_key, rendered_key=manifest_key)

--- a/src/bosh_aws_cpi/bin/test-integration
+++ b/src/bosh_aws_cpi/bin/test-integration
@@ -22,7 +22,7 @@ function create_env() {
     -var "access_key=${AWS_ACCESS_KEY_ID}" \
     -var "secret_key=${AWS_SECRET_ACCESS_KEY}" \
     -var "region=${AWS_DEFAULT_REGION}" \
-    -var "env_name=$(hostname)-local-integration" \
+    -var "env_name=$(hostname -s)-local-integration" \
     -var "public_key=${PUBLIC_KEY}" \
     "${RELEASE_DIR}/ci/assets/terraform"
 

--- a/src/bosh_aws_cpi/bin/test-integration
+++ b/src/bosh_aws_cpi/bin/test-integration
@@ -11,6 +11,7 @@ function destroy_env() {
   terraform destroy -force -state="${STATE_FILE}" \
     -var "access_key=${AWS_ACCESS_KEY_ID}" \
     -var "secret_key=${AWS_SECRET_ACCESS_KEY}" \
+    ${AWS_SESSION_TOKEN:+-var "session_token=${AWS_SESSION_TOKEN}"} \
     -var "region=${AWS_DEFAULT_REGION}" \
     -var "env_name=$(hostname)-local-integration" \
     -var "public_key=${PUBLIC_KEY}" \
@@ -21,6 +22,7 @@ function create_env() {
   terraform apply -state="${STATE_FILE}" \
     -var "access_key=${AWS_ACCESS_KEY_ID}" \
     -var "secret_key=${AWS_SECRET_ACCESS_KEY}" \
+    ${AWS_SESSION_TOKEN:+-var "session_token=${AWS_SESSION_TOKEN}"} \
     -var "region=${AWS_DEFAULT_REGION}" \
     -var "env_name=$(hostname -s)-local-integration" \
     -var "public_key=${PUBLIC_KEY}" \

--- a/src/bosh_aws_cpi/lib/cloud/aws/config.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/config.rb
@@ -17,6 +17,7 @@ module Bosh::AwsCloud
 
       @access_key_id = @config['access_key_id']
       @secret_access_key = @config['secret_access_key']
+      @session_token = @config['session_token']
 
       @stemcell = @config['stemcell'] || {}
       @fast_path_delete = @config['fast_path_delete'] || false
@@ -29,7 +30,7 @@ module Bosh::AwsCloud
       # - if "env_or_profile", credentials are read from instance metadata
       @credentials_source =  @config['credentials_source'] || CREDENTIALS_SOURCE_STATIC
       if @credentials_source == CREDENTIALS_SOURCE_STATIC
-        @credentials = Aws::Credentials.new(@access_key_id, @secret_access_key)
+        @credentials = Aws::Credentials.new(@access_key_id, @secret_access_key, @session_token)
       else
         @credentials = Aws::InstanceProfileCredentials.new({retries: 10})
       end

--- a/src/bosh_aws_cpi/spec/integration/aws_cpi_spec.rb
+++ b/src/bosh_aws_cpi/spec/integration/aws_cpi_spec.rb
@@ -8,6 +8,7 @@ describe 'the aws_cpi executable' do
   before(:all) do
     @access_key_id     = ENV['BOSH_AWS_ACCESS_KEY_ID']       || raise('Missing BOSH_AWS_ACCESS_KEY_ID')
     @secret_access_key = ENV['BOSH_AWS_SECRET_ACCESS_KEY']   || raise('Missing BOSH_AWS_SECRET_ACCESS_KEY')
+    @session_token     = ENV['BOSH_AWS_SESSION_TOKEN']       || nil
     @region            = ENV['BOSH_AWS_REGION']              || 'us-west-1'
   end
 
@@ -25,6 +26,7 @@ describe 'the aws_cpi executable' do
           'aws' => {
             'access_key_id' => @access_key_id,
             'secret_access_key' => @secret_access_key,
+            'session_token' => @session_token,
             'region' => @region,
             'default_key_name' => 'default_key_name',
             'fast_path_delete' => 'yes',
@@ -119,6 +121,7 @@ describe 'the aws_cpi executable' do
         'director_uuid' => 'abc123',
         'access_key_id' => @access_key_id,
         'secret_access_key' => @secret_access_key,
+        'session_token' => @session_token,
         'region' => @region,
         'default_key_name' => 'default_key_name',
         'fast_path_delete' => 'yes',

--- a/src/bosh_aws_cpi/spec/integration/endpoint_spec.rb
+++ b/src/bosh_aws_cpi/spec/integration/endpoint_spec.rb
@@ -7,6 +7,7 @@ describe Bosh::AwsCloud::Cloud do
   before(:all) do
     @access_key_id     = ENV['BOSH_AWS_ACCESS_KEY_ID']       || raise("Missing BOSH_AWS_ACCESS_KEY_ID")
     @secret_access_key = ENV['BOSH_AWS_SECRET_ACCESS_KEY']   || raise("Missing BOSH_AWS_SECRET_ACCESS_KEY")
+    @session_token     = ENV['BOSH_AWS_SESSION_TOKEN']       || nil
     @region            = ENV['BOSH_AWS_REGION']              || 'us-west-1'
   end
 
@@ -24,6 +25,7 @@ describe Bosh::AwsCloud::Cloud do
           'access_key_id' => @access_key_id,
           'default_key_name' => 'fake-key',
           'secret_access_key' => @secret_access_key,
+          'session_token' => @session_token,
           'max_retries' => 8
         },
         'registry' => {
@@ -49,6 +51,7 @@ describe Bosh::AwsCloud::Cloud do
             'access_key_id' => @access_key_id,
             'default_key_name' => 'fake-key',
             'secret_access_key' => @secret_access_key,
+            'session_token' => @session_token,
             'max_retries' => 8
           },
           'registry' => {
@@ -77,6 +80,7 @@ describe Bosh::AwsCloud::Cloud do
             'access_key_id' => @access_key_id,
             'default_key_name' => 'fake-key',
             'secret_access_key' => @secret_access_key,
+            'session_token' => @session_token,
             'max_retries' => 8
           },
           'registry' => {
@@ -139,6 +143,7 @@ describe Bosh::AwsCloud::Cloud do
           'default_key_name' => 'fake-key',
           'access_key_id' => @access_key_id,
           'secret_access_key' => @secret_access_key,
+          'session_token' => @session_token,
           'max_retries' => 8
         },
         'registry' => {
@@ -203,6 +208,7 @@ describe Bosh::AwsCloud::Cloud do
             'access_key_id' => @access_key_id,
             'default_key_name' => 'fake-key',
             'secret_access_key' => @secret_access_key,
+            'session_token' => @session_token,
             'max_retries' => 8
           },
           'registry' => {

--- a/src/bosh_aws_cpi/spec/integration/lifecycle_spec.rb
+++ b/src/bosh_aws_cpi/spec/integration/lifecycle_spec.rb
@@ -63,6 +63,7 @@ describe Bosh::AwsCloud::Cloud do
           'fast_path_delete' => 'yes',
           'access_key_id' => @access_key_id,
           'secret_access_key' => @secret_access_key,
+          'session_token' => @session_token,
           'max_retries' => 0
         },
         'registry' => {
@@ -188,6 +189,7 @@ describe Bosh::AwsCloud::Cloud do
             'fast_path_delete' => 'yes',
             'access_key_id' => @access_key_id,
             'secret_access_key' => @secret_access_key,
+            'session_token' => @session_token,
             'max_retries' => 8
           },
           'registry' => {

--- a/src/bosh_aws_cpi/spec/integration/light_stemcell_spec.rb
+++ b/src/bosh_aws_cpi/spec/integration/light_stemcell_spec.rb
@@ -18,6 +18,7 @@ describe Bosh::AwsCloud::Cloud do
       'fast_path_delete' => 'yes',
       'access_key_id' => @access_key_id,
       'secret_access_key' => @secret_access_key,
+      'session_token' => @session_token,
       'max_retries' => 8,
       'encrypted' => true
     }
@@ -93,6 +94,7 @@ describe Bosh::AwsCloud::Cloud do
             'fast_path_delete' => 'yes',
             'access_key_id' => @access_key_id,
             'secret_access_key' => @secret_access_key,
+            'session_token' => @session_token,
             'max_retries' => 8,
             'encrypted' => true,
             'kms_key_arn' => @kms_key_arn

--- a/src/bosh_aws_cpi/spec/integration/manual_network_spec.rb
+++ b/src/bosh_aws_cpi/spec/integration/manual_network_spec.rb
@@ -43,6 +43,7 @@ describe Bosh::AwsCloud::Cloud do
       'fast_path_delete' => 'yes',
       'access_key_id' => @access_key_id,
       'secret_access_key' => @secret_access_key,
+      'session_token' => @session_token,
       'max_retries' => 8,
       'encrypted' => true
     }
@@ -140,6 +141,7 @@ describe Bosh::AwsCloud::Cloud do
               'fast_path_delete' => 'yes',
               'access_key_id' => @access_key_id,
               'secret_access_key' => @secret_access_key,
+              'session_token' => @session_token,
               'max_retries' => 8,
               'request_id' => '419877'
             },
@@ -173,6 +175,7 @@ describe Bosh::AwsCloud::Cloud do
               'fast_path_delete' => 'yes',
               'access_key_id' => @access_key_id,
               'secret_access_key' => @secret_access_key,
+              'session_token' => @session_token,
               'max_retries' => 8
             },
             'registry' => {
@@ -206,6 +209,7 @@ describe Bosh::AwsCloud::Cloud do
         Aws::ElasticLoadBalancing::Client.new(
           access_key_id: @access_key_id,
           secret_access_key: @secret_access_key,
+          session_token:  @session_token,
           region: @region,
         )
       end
@@ -242,6 +246,7 @@ describe Bosh::AwsCloud::Cloud do
         Aws::ElasticLoadBalancingV2::Client.new(
           access_key_id: @access_key_id,
           secret_access_key: @secret_access_key,
+          session_token:  @session_token,
           region: @region,
         )
       end
@@ -407,6 +412,7 @@ describe Bosh::AwsCloud::Cloud do
           'fast_path_delete' => 'yes',
           'access_key_id' => @access_key_id,
           'secret_access_key' => @secret_access_key,
+          'session_token' => @session_token,
           'max_retries' => 8,
           'encrypted' => true
         }
@@ -449,6 +455,7 @@ describe Bosh::AwsCloud::Cloud do
             'fast_path_delete' => 'yes',
             'access_key_id' => @access_key_id,
             'secret_access_key' => @secret_access_key,
+            'session_token' => @session_token,
             'max_retries' => 8,
             'encrypted' => true,
             'kms_key_arn' => @kms_key_arn

--- a/src/bosh_aws_cpi/spec/integration/resources/classic_lb_spec.rb
+++ b/src/bosh_aws_cpi/spec/integration/resources/classic_lb_spec.rb
@@ -5,6 +5,7 @@ describe Bosh::AwsCloud::ClassicLB do
     Aws::ElasticLoadBalancing::Client.new(
       access_key_id: @access_key_id,
       secret_access_key: @secret_access_key,
+      session_token:  @session_token,
       region: @region,
     )
   end

--- a/src/bosh_aws_cpi/spec/integration/resources/lb_target_group_spec.rb
+++ b/src/bosh_aws_cpi/spec/integration/resources/lb_target_group_spec.rb
@@ -5,6 +5,7 @@ describe Bosh::AwsCloud::LBTargetGroup do
     Aws::ElasticLoadBalancingV2::Client.new(
       access_key_id: @access_key_id,
       secret_access_key: @secret_access_key,
+      session_token:  @session_token,
       region: @region,
     )
   end

--- a/src/bosh_aws_cpi/spec/integration/spec_helper.rb
+++ b/src/bosh_aws_cpi/spec/integration/spec_helper.rb
@@ -7,6 +7,7 @@ RSpec.configure do |rspec_config|
   rspec_config.before(:each) do
     @access_key_id      = ENV['BOSH_AWS_ACCESS_KEY_ID']       || raise('Missing BOSH_AWS_ACCESS_KEY_ID')
     @secret_access_key  = ENV['BOSH_AWS_SECRET_ACCESS_KEY']   || raise('Missing BOSH_AWS_SECRET_ACCESS_KEY')
+    @session_token      = ENV['BOSH_AWS_SESSION_TOKEN']       || nil
     @subnet_id          = ENV['BOSH_AWS_SUBNET_ID']           || raise('Missing BOSH_AWS_SUBNET_ID')
     @subnet_zone        = ENV['BOSH_AWS_SUBNET_ZONE']         || raise('Missing BOSH_AWS_SUBNET_ZONE')
     @region             = ENV.fetch('BOSH_AWS_REGION', 'us-west-1')
@@ -18,6 +19,7 @@ RSpec.configure do |rspec_config|
       region:      @region,
       access_key_id: @access_key_id,
       secret_access_key: @secret_access_key,
+      session_token: @session_token,
       logger: logger,
     )
     @ec2 = Aws::EC2::Resource.new(client: ec2_client)
@@ -34,6 +36,7 @@ RSpec.configure do |rspec_config|
         'fast_path_delete' => 'yes',
         'access_key_id' => @access_key_id,
         'secret_access_key' => @secret_access_key,
+        'session_token' =>  @session_token,
         'max_retries' => 8
       },
       'registry' => {

--- a/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -51,6 +51,7 @@ describe 'cpi.json.erb' do
             'credentials_source' => 'static',
             'access_key_id' => nil,
             'secret_access_key' => nil,
+            'session_token' => nil,
             'default_iam_instance_profile' => nil,
             'default_key_name'=>'the_default_key_name',
             'default_security_groups'=>['security_group_1'],
@@ -126,6 +127,19 @@ describe 'cpi.json.erb' do
       expect(subject['cloud']['properties']['aws']['credentials_source']).to eq('static')
       expect(subject['cloud']['properties']['aws']['access_key_id']).to eq('some key')
       expect(subject['cloud']['properties']['aws']['secret_access_key']).to eq('some secret')
+      expect(subject['cloud']['properties']['aws']['session_token']).to be_nil
+    end
+
+    context 'incluing a session_token' do
+      before do
+        manifest['properties']['aws'].merge!({
+          'session_token' => 'some token'
+        })
+      end
+
+      it 'is able to render the erb given access key id and secret access key' do
+        expect(subject['cloud']['properties']['aws']['session_token']).to eq('some token')
+      end
     end
   end
 
@@ -168,6 +182,7 @@ describe 'cpi.json.erb' do
               'credentials_source' => 'static',
               'access_key_id' => 'blobstore-access-key-id',
               'secret_access_key' => 'blobstore-secret-access-key',
+              'session_token' => nil,
               'use_ssl' => true,
               'port' => 443,
             }
@@ -194,6 +209,7 @@ describe 'cpi.json.erb' do
               'credentials_source' => 'env_or_profile',
               'access_key_id' => nil,
               'secret_access_key' => nil,
+              'session_token' => nil,
               'use_ssl' => true,
               'port' => 443,
             }
@@ -210,6 +226,7 @@ describe 'cpi.json.erb' do
           'credentials_source' => 'blobstore-credentials-source',
           'access_key_id' => 'blobstore-access-key-id',
           'secret_access_key' => 'blobstore-secret-access-key',
+          'session_token' => 'blobstore-session-token',
           's3_region' => 'blobstore-region',
           'use_ssl' => false,
           's3_port' => 21,
@@ -230,6 +247,7 @@ describe 'cpi.json.erb' do
               'credentials_source' => 'blobstore-credentials-source',
               'access_key_id' => 'blobstore-access-key-id',
               'secret_access_key' => 'blobstore-secret-access-key',
+              'session_token' => nil,
               'region' => 'blobstore-region',
               'use_ssl' => false,
               'host' => 'blobstore-host',
@@ -249,6 +267,7 @@ describe 'cpi.json.erb' do
             'credentials_source' => 'agent-credentials-source',
             'access_key_id' => 'agent_access_key_id',
             'secret_access_key' => 'agent_secret_access_key',
+            'session_token' => 'agent_session_token',
             's3_region' => 'agent-region',
             'use_ssl' => true,
             's3_port' => 42,
@@ -264,6 +283,7 @@ describe 'cpi.json.erb' do
           'credentials_source' => 'blobstore-credentials-source',
           'access_key_id' => 'blobstore_access_key_id',
           'secret_access_key' => 'blobstore_secret_access_key',
+          'session_token' => 'blobstore_session_token',
           's3_region' => 'blobstore-region',
           'use_ssl' => false,
           's3_port' => 21,


### PR DESCRIPTION
Allow optionally define the `session_token` attribute together with the `access_key_id` and the `secret_access_key`, enabling the user of the CPI to use all the possible authentication mechanism in AWS.

This PR extends the feature and allows run the integration tests using STS credentials.

This covers the use cases from the issue #60

Use cases and justification
--------------------------

As developers and operators, we should avoid use permanent AWS credentials that might be leaked and then abused. We should encourage and allow to use [AWS Temporary Security credentials (STS)](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html).

These credentials have a maximum TTL of 36 hours.

It has been argued that is pointless to use these kind of credentials with the CPI, but there are several reasons and cases:

 * For security, it is not recommended work with permanent credentials. Specially during development.
 * Some organisations disallow usage of permanent credentials at all.
 * STS credentials are used when accessing with [Federated AWS authentication](https://aws.amazon.com/iam/details/manage-federation/)
 * STS credentials are used for assumed roles and iam profiles. Use cases:
   * using the CPI across multiple roles and accounts.
   * automation on hosts.
 * Currently it is not possible to provision a new environment with STS credentials.

How to test?
------------

I added an additional test that would test the STS credentials when using permanent keys. But otherwise you can test it by using something like:

```
aws sts get-session-token \
    --duration-seconds 3600 \
    --output text \
    --query '[Credentials.AccessKeyId,Credentials.SecretAccessKey,Credentials.SessionToken]' \
    ${token:+--token-code "${token}"} | \
      awk '{ print "export AWS_ACCESS_KEY_ID=\"" $1 "\"\n" "export AWS_SECRET_ACCESS_KEY=\"" $2 "\"\n" "export AWS_SESSION_TOKEN=\"" $3 "\"" }'
```

(via https://github.com/keymon/aws_key_management)

Comments
--------

 * I plan to also do a PR to allow consume the credentials from environment variables.
 * I was not sure of the right location for new test `using STS credentials`. Suggestions?