### PR TITLE
Allow users to override auto_assign_public_ip to false

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud_props.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud_props.rb
@@ -112,7 +112,7 @@ module Bosh::AwsCloud
       @iam_instance_profile = cloud_properties['iam_instance_profile'] || global_config.aws.default_iam_instance_profile
       @placement_group = cloud_properties['placement_group']
       @tenancy = Tenancy.new(cloud_properties['tenancy'])
-      @auto_assign_public_ip = !!cloud_properties['auto_assign_public_ip']
+      @auto_assign_public_ip = cloud_properties['auto_assign_public_ip']
       @advertised_routes = (cloud_properties['advertised_routes'] || []).map do |route|
         AdvertisedRoute.new(route)
       end

--- a/src/bosh_aws_cpi/lib/cloud/aws/instance_param_mapper.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/instance_param_mapper.rb
@@ -89,7 +89,7 @@ module Bosh::AwsCloud
         end
       end
 
-      nic[:associate_public_ip_address] = vm_type.auto_assign_public_ip if vm_type.auto_assign_public_ip
+      nic[:associate_public_ip_address] = vm_type.auto_assign_public_ip unless vm_type.auto_assign_public_ip.nil?
 
       nic[:device_index] = 0 unless nic.empty?
       params[:network_interfaces] = [nic] unless nic.empty?

--- a/src/bosh_aws_cpi/spec/unit/instance_param_mapper_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/instance_param_mapper_spec.rb
@@ -465,6 +465,30 @@ module Bosh::AwsCloud
           end
         end
 
+        context 'when associate_public_ip_address is false' do
+          let(:vm_type) { { 'auto_assign_public_ip' => false } }
+          let(:input) do
+            {
+                vm_type: vm_cloud_props,
+                networks_spec: network_cloud_props,
+            }
+          end
+          let(:output) do
+            {
+                network_interfaces: [
+                    {
+                        associate_public_ip_address: false,
+                        device_index: 0
+                    }
+                ]
+            }
+          end
+
+          it 'adds the option to the output' do
+            expect(mapping(input)).to eq(output)
+          end
+        end
+
         context 'when the one manual network address is IPv6' do
           let(:networks_spec) do
             {


### PR DESCRIPTION
- allows users to override auto assign public ips when subnets have this
enabled by default

Fixes https://github.com/cloudfoundry/bosh/issues/1885

[finishes #154861697](https://www.pivotaltracker.com/story/show/154861697)