### PR TITLE
Tag resources on creation

### DIFF
--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud_props.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud_props.rb
@@ -63,7 +63,7 @@ module Bosh::AwsCloud
   end
 
   class DiskCloudProps
-    attr_reader :type, :iops, :throughput, :encrypted, :kms_key_arn
+    attr_reader :type, :iops, :throughput, :encrypted, :kms_key_arn, :tags
 
     # @param [Hash] cloud_properties
     # @param [Bosh::AwsCloud::Config] global_config
@@ -76,6 +76,9 @@ module Bosh::AwsCloud
 
       @kms_key_arn = global_config.aws.kms_key_arn
       @kms_key_arn = cloud_properties['kms_key_arn'] if cloud_properties.key?('kms_key_arn')
+
+      raw_tags = cloud_properties['tags']
+      @tags = raw_tags.is_a?(Hash) ? raw_tags : {}
     end
   end
 

--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud_v1.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud_v1.rb
@@ -204,6 +204,8 @@ module Bosh::AwsCloud
       with_thread_name("create_disk(#{size}, #{instance_id})") do
         props = @props_factory.disk_props(cloud_properties)
 
+        tag_list = props.tags.empty? ? [] : TagManager.format_tags(props.tags)
+
         volume_properties = VolumeProperties.new(
           size: size,
           type: props.type,
@@ -211,7 +213,8 @@ module Bosh::AwsCloud
           throughput: props.throughput,
           az: @az_selector.select_availability_zone(instance_id),
           encrypted: props.encrypted,
-          kms_key_arn: props.kms_key_arn
+          kms_key_arn: props.kms_key_arn,
+          tags: tag_list
         )
         volume = @volume_manager.create_ebs_volume(**volume_properties.persistent_disk_config)
 
@@ -308,21 +311,27 @@ module Bosh::AwsCloud
           metadata['device'] = devices.first
         end
 
-        snapshot = volume.create_snapshot(description: name.join('/'))
-        logger.info("snapshot '#{snapshot.id}' of volume '#{disk_id}' created")
+        description = name.join('/')
 
         metadata.merge!(
           'director' => metadata['director_name'],
           'instance_index' => metadata['index'].to_s,
           'instance_name' => metadata['job'] + '/' + metadata['instance_id'],
-          'Name' => name.join('/')
+          'Name' => description
         )
 
         %w[director_name index job].each do |tag|
           metadata.delete(tag)
         end
 
-        TagManager.create_tags(snapshot, **metadata)
+        snapshot_opts = {
+          description: description,
+          tag_specifications: TagManager.tag_specifications_for_resources(metadata, ['snapshot']),
+        }
+
+        snapshot = volume.create_snapshot(snapshot_opts)
+        logger.info("snapshot '#{snapshot.id}' of volume '#{disk_id}' created")
+
         ResourceWait.for_snapshot(snapshot: snapshot, state: 'completed')
         snapshot.id
       end
@@ -451,7 +460,7 @@ module Bosh::AwsCloud
       logger.debug("updated registry settings: #{registry.read_settings(instance_id)}")
     end
 
-    def create_ami_for_stemcell(image_path, stemcell_cloud_props)
+    def create_ami_for_stemcell(image_path, stemcell_cloud_props, tags = nil)
       creator = StemcellCreator.new(@ec2_resource, stemcell_cloud_props)
 
       begin
@@ -467,11 +476,13 @@ module Bosh::AwsCloud
           )
         end
 
+        stemcell_tags = stemcell_creation_tags(tags)
         disk_config = VolumeProperties.new(
           size: stemcell_cloud_props.disk,
           az: @az_selector.select_availability_zone(director_vm_id),
           encrypted: stemcell_cloud_props.encrypted,
-          kms_key_arn: stemcell_cloud_props.kms_key_arn
+          kms_key_arn: stemcell_cloud_props.kms_key_arn,
+          tags: stemcell_tags
         ).persistent_disk_config
         volume = @volume_manager.create_ebs_volume(disk_config)
         requested_path = @volume_manager.attach_ebs_volume(instance, volume)
@@ -488,7 +499,7 @@ module Bosh::AwsCloud
 
         logger.debug("Actual block device: #{actual_path}")
         logger.info("Creating stemcell with: '#{volume.id}'")
-        creator.create(volume, actual_path, image_path).id
+        creator.create(volume, actual_path, image_path, tags).id
       rescue => e
         logger.error(e)
         raise e
@@ -503,6 +514,12 @@ module Bosh::AwsCloud
     def get_volume_ids_for_vm(vm_instance)
       vm_instance.block_device_mappings.select(&:ebs)
                  .map { |block_device| block_device.ebs.volume_id }
+    end
+
+    def stemcell_creation_tags(tags)
+      return [] if tags.nil? || !tags.is_a?(Hash) || tags.empty?
+
+      TagManager.format_tags(tags)
     end
   end
 end

--- a/src/bosh_aws_cpi/lib/cloud/aws/cloud_v3.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/cloud_v3.rb
@@ -48,21 +48,21 @@ module Bosh::AwsCloud
           raise Bosh::Clouds::CloudError, "Stemcell does not contain an AMI in region #{@config.aws.region}" unless available_image
 
           if props.encrypted
-            copy_image_result = @ec2_client.copy_image(
+            copy_opts = {
               source_region: @config.aws.region,
               source_image_id: props.region_ami,
               name: "Copied from SourceAMI #{props.region_ami}",
               encrypted: props.encrypted,
               kms_key_id: props.kms_key_arn,
-            )
+            }
+            img_specs = TagManager.tag_specifications_for_resources(tags, ["image"])
+            copy_opts[:tag_specifications] = img_specs unless img_specs.empty?
+
+            copy_image_result = @ec2_client.copy_image(**copy_opts)
 
             encrypted_image_id = copy_image_result.image_id
             encrypted_image = @ec2_resource.image(encrypted_image_id)
             ResourceWait.for_image(image: encrypted_image, state: "available")
-
-            if !tags.nil?
-              TagManager.create_tags(encrypted_image, tags)
-            end
 
             return encrypted_image_id.to_s
           end
@@ -73,19 +73,13 @@ module Bosh::AwsCloud
 
           "#{available_image.id} light"
         else
-          stemcell_id = create_ami_for_stemcell(image_path, props)
+          stemcell_id = create_ami_for_stemcell(image_path, props, tags)
 
-          if !tags.nil?
-            created_ami = @ec2_resource.images(
-              filters: [{
-                          name: "image-id",
-                          values: [stemcell_id],
-                        }]
-              ).first
-
-            TagManager.create_tags(created_ami, tags)
+          if tags.is_a?(Hash) && !tags.empty?
+            logger.info("Created stemcell AMI #{stemcell_id} with env tags applied at resource creation: #{tags.inspect}")
+          else
+            logger.info("Created stemcell AMI #{stemcell_id}.")
           end
-          logger.info("Tagged #{stemcell_id} with #{tags}.")
           stemcell_id
         end
       end

--- a/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
@@ -17,7 +17,7 @@ module Bosh::AwsCloud
       abruptly_terminated_retries = 2
       begin
         network_interface_manager = Bosh::AwsCloud::NetworkInterfaceManager.new(@ec2, @logger)
-        network_interfaces = network_interface_manager.create_network_interfaces(networks_cloud_props, vm_cloud_props, default_security_groups)
+        network_interfaces = network_interface_manager.create_network_interfaces(networks_cloud_props, vm_cloud_props, default_security_groups, tags)
 
         settings.update_agent_settings(networks_cloud_props)
 

--- a/src/bosh_aws_cpi/lib/cloud/aws/instance_param_mapper.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/instance_param_mapper.rb
@@ -60,15 +60,9 @@ module Bosh::AwsCloud
         metadata_options: metadata_options,
         network_interfaces: network_interfaces.map.with_index { |nic, index| nic.nic_configuration(index) }
       }
-      unless @manifest_params[:tags].nil? || @manifest_params[:tags].empty?
-        params.merge!(
-          tag_specifications: [
-            {
-              resource_type: 'instance',
-              tags: @manifest_params[:tags].map { |k, v| { key: k, value: v } }
-            }
-          ]
-        )
+      tag_specs = TagManager.tag_specifications_for_resources(@manifest_params[:tags], %w[instance volume])
+      unless tag_specs.empty?
+        params[:tag_specifications] = tag_specs
       end
 
       az = availability_zone(network_interfaces.first.availability_zone)

--- a/src/bosh_aws_cpi/lib/cloud/aws/network_interface_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/network_interface_manager.rb
@@ -7,7 +7,7 @@ module Bosh::AwsCloud
       @logger = logger
     end
 
-    def create_network_interfaces(networks_cloud_props, vm_cloud_props, default_security_groups)
+    def create_network_interfaces(networks_cloud_props, vm_cloud_props, default_security_groups, tags = nil)
       nic_groups = {}
       security_group_mapper = SecurityGroupMapper.new(@ec2_resource)
 
@@ -23,7 +23,7 @@ module Bosh::AwsCloud
 
       validate_subnet_az_mapping(nic_groups)
 
-      provision_network_interfaces(nic_groups, networks_cloud_props, vm_cloud_props, default_security_groups, security_group_mapper)
+      provision_network_interfaces(nic_groups, networks_cloud_props, vm_cloud_props, default_security_groups, security_group_mapper, tags)
     end
 
     def set_delete_on_termination_for_network_interfaces(network_interfaces)
@@ -57,7 +57,7 @@ module Bosh::AwsCloud
 
     private
 
-    def provision_network_interfaces(nic_groups, network_cloud_props, vm_cloud_props, default_security_groups, security_group_mapper)
+    def provision_network_interfaces(nic_groups, network_cloud_props, vm_cloud_props, default_security_groups, security_group_mapper, tags)
       network_interfaces = []
       nic_groups.each_value do |nic_group|
         # Get subnet from the nic_group
@@ -79,6 +79,9 @@ module Bosh::AwsCloud
           nic[:ipv_6_addresses] = [{ ipv_6_address: nic_group.ipv6_address }] if nic_group.has_ipv6_address?
           nic[:private_ip_address] = nic_group.ipv4_address if nic_group.has_ipv4_address?
         end
+
+        nic_tag_specs = TagManager.tag_specifications_for_resources(tags, ['network-interface'])
+        nic[:tag_specifications] = nic_tag_specs unless nic_tag_specs.empty?
 
         prefixes = nic_group.prefixes
         begin

--- a/src/bosh_aws_cpi/lib/cloud/aws/stemcell_creator.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/stemcell_creator.rb
@@ -9,24 +9,27 @@ module Bosh::AwsCloud
     def initialize(resource, stemcell_props)
       @resource = resource
       @stemcell_props = stemcell_props
+      @creation_tags = nil
     end
 
-    def create(volume, device_path, image_path)
+    # @param tags [Hash, nil] optional string-key tag hash (e.g. Director env tags) applied at snapshot and AMI registration
+    def create(volume, device_path, image_path, tags = nil)
       @volume = volume
       @device_path = device_path
       @image_path = image_path
+      @creation_tags = tags
 
       copy_root_image
 
-      snapshot = volume.create_snapshot
+      snapshot = volume.create_snapshot(
+        tag_specifications: TagManager.tag_specifications_for_resources(@creation_tags, ['snapshot']),
+      )
       ResourceWait.for_snapshot(snapshot: snapshot, state: 'completed')
 
       # the top-level ec2 class' ImageCollection.create does not support the full set of params
       params = image_params(snapshot.id)
       image = resource.images(filters: [{name: 'image-id', values: [resource.client.register_image(params).image_id]}]).first
       ResourceWait.for_image(image: image, state: 'available')
-
-      TagManager.tag(image, 'Name', params[:description]) if params[:description]
 
       Stemcell.new(resource, image)
     end
@@ -117,6 +120,11 @@ module Bosh::AwsCloud
       )
 
       params[:block_device_mappings].push(BlockDeviceManager::DEFAULT_INSTANCE_STORAGE_DISK_MAPPING)
+
+      image_tag_hash = @creation_tags ? @creation_tags.dup : {}
+      image_tag_hash['Name'] = params[:description] if params[:description]
+      img_specs = TagManager.tag_specifications_for_resources(image_tag_hash, ['image'])
+      params[:tag_specifications] = img_specs unless img_specs.empty?
 
       params
     end

--- a/src/bosh_aws_cpi/lib/cloud/aws/tag_manager.rb
+++ b/src/bosh_aws_cpi/lib/cloud/aws/tag_manager.rb
@@ -51,5 +51,14 @@ module Bosh::AwsCloud
 
       formatted_tags.compact
     end
+
+    def self.tag_specifications_for_resources(tags_hash, resource_types)
+      return [] if tags_hash.nil? || tags_hash.empty?
+
+      formatted = format_tags(tags_hash)
+      return [] if formatted.empty?
+
+      Array(resource_types).map { |rt| { resource_type: rt, tags: formatted } }
+    end
   end
 end

--- a/src/bosh_aws_cpi/spec/unit/cloud_v3_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/cloud_v3_spec.rb
@@ -117,54 +117,92 @@ describe Bosh::AwsCloud::CloudV3 do
           },
         }
       end
-      let(:cloud) {
-        mock_cloud_v3 do |ec2|
-          expect(ec2).to receive(:images).with(
-            filters: [{
-              name: "image-id",
-              values: [ami_id],
-            }],
-            include_deprecated: true,
-          ).and_return([image])
 
-          expect(ec2.client).to receive(:copy_image).with(
-            source_region: "us-east-1",
-            source_image_id: ami_id,
-            name: "Copied from SourceAMI #{ami_id}",
-            encrypted: true,
-            kms_key_id: kms_key_arn,
-          ).and_return(image_copy)
+      context "when env tags are passed for copy_image" do
+        let(:cloud) {
+          mock_cloud_v3 do |ec2|
+            expect(ec2).to receive(:images).with(
+              filters: [{
+                name: "image-id",
+                values: [ami_id],
+              }],
+              include_deprecated: true,
+            ).and_return([image])
 
-          expect(ec2).to receive(:image).with("ami-image-id-copy").and_return(encrypted_image)
+            expect(ec2.client).to receive(:copy_image).with(
+              source_region: "us-east-1",
+              source_image_id: ami_id,
+              name: "Copied from SourceAMI #{ami_id}",
+              encrypted: true,
+              kms_key_id: kms_key_arn,
+              tag_specifications: [
+                {
+                  resource_type: "image",
+                  tags: [{ key: "any", value: "value" }],
+                },
+              ],
+            ).and_return(image_copy)
 
-          expect(Bosh::AwsCloud::ResourceWait).to receive(:for_image).with(
-            image: encrypted_image,
-            state: "available",
-          )
+            expect(ec2).to receive(:image).with("ami-image-id-copy").and_return(encrypted_image)
+
+            expect(Bosh::AwsCloud::ResourceWait).to receive(:for_image).with(
+              image: encrypted_image,
+              state: "available",
+            )
+          end
+        }
+
+        it "applies tag_specifications on copy_image" do
+          env = { "tags" => { "any" => "value" } }
+          expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
+          cloud.create_stemcell(image, stemcell_properties, env)
         end
-      }
-
-      it "if tags are provided" do
-        env = { "tags" => { "any" => "value" } }
-        expect(Bosh::AwsCloud::TagManager).to receive(:create_tags).with(encrypted_image, env["tags"])
-        cloud.create_stemcell(image, stemcell_properties, env)
       end
 
-      it "if tags are not provided" do
-        env = {}
-        expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
-        cloud.create_stemcell(image, stemcell_properties, env)
-      end
+      context "when no tag_specifications on copy_image" do
+        let(:cloud) {
+          mock_cloud_v3 do |ec2|
+            expect(ec2).to receive(:images).with(
+              filters: [{
+                name: "image-id",
+                values: [ami_id],
+              }],
+              include_deprecated: true,
+            ).and_return([image])
 
-      it "if tags are nil" do
-        env = { "tags" => nil }
-        expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
-        cloud.create_stemcell(image, stemcell_properties, env)
-      end
+            expect(ec2.client).to receive(:copy_image).with(
+              source_region: "us-east-1",
+              source_image_id: ami_id,
+              name: "Copied from SourceAMI #{ami_id}",
+              encrypted: true,
+              kms_key_id: kms_key_arn,
+            ).and_return(image_copy)
 
-      it "if no env is provided" do
-        expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
-        cloud.create_stemcell(image, stemcell_properties)
+            expect(ec2).to receive(:image).with("ami-image-id-copy").and_return(encrypted_image)
+
+            expect(Bosh::AwsCloud::ResourceWait).to receive(:for_image).with(
+              image: encrypted_image,
+              state: "available",
+            )
+          end
+        }
+
+        it "if tags are not provided" do
+          env = {}
+          expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
+          cloud.create_stemcell(image, stemcell_properties, env)
+        end
+
+        it "if tags are nil" do
+          env = { "tags" => nil }
+          expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
+          cloud.create_stemcell(image, stemcell_properties, env)
+        end
+
+        it "if no env is provided" do
+          expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
+          cloud.create_stemcell(image, stemcell_properties)
+        end
       end
     end
 
@@ -179,54 +217,92 @@ describe Bosh::AwsCloud::CloudV3 do
           },
         }
       end
-      let(:cloud) {
-        mock_cloud_v3 do |ec2|
-          expect(ec2).to receive(:images).with(
-            filters: [{
-              name: "image-id",
-              values: [ami_id],
-            }],
-            include_deprecated: true,
-          ).and_return([image])
 
-          expect(ec2.client).to receive(:copy_image).with(
-            source_region: "us-east-1",
-            source_image_id: ami_id,
-            name: "Copied from SourceAMI #{ami_id}",
-            encrypted: true,
-            kms_key_id: kms_key_arn,
-          ).and_return(image_copy)
+      context "when env tags are passed for copy_image" do
+        let(:cloud) {
+          mock_cloud_v3 do |ec2|
+            expect(ec2).to receive(:images).with(
+              filters: [{
+                name: "image-id",
+                values: [ami_id],
+              }],
+              include_deprecated: true,
+            ).and_return([image])
 
-          expect(ec2).to receive(:image).with("ami-image-id-copy").and_return(encrypted_image)
+            expect(ec2.client).to receive(:copy_image).with(
+              source_region: "us-east-1",
+              source_image_id: ami_id,
+              name: "Copied from SourceAMI #{ami_id}",
+              encrypted: true,
+              kms_key_id: kms_key_arn,
+              tag_specifications: [
+                {
+                  resource_type: "image",
+                  tags: [{ key: "any", value: "value" }],
+                },
+              ],
+            ).and_return(image_copy)
 
-          expect(Bosh::AwsCloud::ResourceWait).to receive(:for_image).with(
-            image: encrypted_image,
-            state: "available",
-          )
+            expect(ec2).to receive(:image).with("ami-image-id-copy").and_return(encrypted_image)
+
+            expect(Bosh::AwsCloud::ResourceWait).to receive(:for_image).with(
+              image: encrypted_image,
+              state: "available",
+            )
+          end
+        }
+
+        it "applies tag_specifications on copy_image" do
+          env = { "tags" => { "any" => "value" } }
+          expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
+          cloud.create_stemcell(image, stemcell_properties, env)
         end
-      }
-
-      it "if tags are provided" do
-        env = { "tags" => { "any" => "value" } }
-        expect(Bosh::AwsCloud::TagManager).to receive(:create_tags).with(encrypted_image, env["tags"])
-        cloud.create_stemcell(image, stemcell_properties, env)
       end
 
-      it "if tags are not provided" do
-        env = {}
-        expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
-        cloud.create_stemcell(image, stemcell_properties, env)
-      end
+      context "when no tag_specifications on copy_image" do
+        let(:cloud) {
+          mock_cloud_v3 do |ec2|
+            expect(ec2).to receive(:images).with(
+              filters: [{
+                name: "image-id",
+                values: [ami_id],
+              }],
+              include_deprecated: true,
+            ).and_return([image])
 
-      it "if tags are nil" do
-        env = { "tags" => nil }
-        expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
-        cloud.create_stemcell(image, stemcell_properties, env)
-      end
+            expect(ec2.client).to receive(:copy_image).with(
+              source_region: "us-east-1",
+              source_image_id: ami_id,
+              name: "Copied from SourceAMI #{ami_id}",
+              encrypted: true,
+              kms_key_id: kms_key_arn,
+            ).and_return(image_copy)
 
-      it "if no env is provided" do
-        expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
-        cloud.create_stemcell(image, stemcell_properties)
+            expect(ec2).to receive(:image).with("ami-image-id-copy").and_return(encrypted_image)
+
+            expect(Bosh::AwsCloud::ResourceWait).to receive(:for_image).with(
+              image: encrypted_image,
+              state: "available",
+            )
+          end
+        }
+
+        it "if tags are not provided" do
+          env = {}
+          expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
+          cloud.create_stemcell(image, stemcell_properties, env)
+        end
+
+        it "if tags are nil" do
+          env = { "tags" => nil }
+          expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
+          cloud.create_stemcell(image, stemcell_properties, env)
+        end
+
+        it "if no env is provided" do
+          expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
+          cloud.create_stemcell(image, stemcell_properties)
+        end
       end
     end
 
@@ -257,29 +333,48 @@ describe Bosh::AwsCloud::CloudV3 do
       let(:stemcell_cloud_props) { Bosh::AwsCloud::StemcellCloudProps.new(stemcell_properties, global_config) }
       let(:props_factory) { instance_double(Bosh::AwsCloud::PropsFactory) }
 
-      before do
-        allow(cloud).to receive(:create_ami_for_stemcell).and_return(ami_id)
-      end
-
       it "if tags are provided" do
         env = { "tags" => { "any" => "value" } }
-        expect(Bosh::AwsCloud::TagManager).to receive(:create_tags).with(image, env["tags"])
+        expect(cloud).to receive(:create_ami_for_stemcell).with(
+          image,
+          instance_of(Bosh::AwsCloud::StemcellCloudProps),
+          env["tags"],
+        ).and_return(ami_id)
+        expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
+        expect(cloud.logger).to receive(:info).with(
+          "Created stemcell AMI #{ami_id} with env tags applied at resource creation: #{env['tags'].inspect}",
+        )
         cloud.create_stemcell(image, stemcell_properties, env)
       end
 
       it "if tags are not provided" do
         env = {}
+        expect(cloud).to receive(:create_ami_for_stemcell).with(
+          image,
+          instance_of(Bosh::AwsCloud::StemcellCloudProps),
+          nil,
+        ).and_return(ami_id)
         expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
         cloud.create_stemcell(image, stemcell_properties, env)
       end
 
       it "if tags are nil" do
         env = { "tags" => nil }
+        expect(cloud).to receive(:create_ami_for_stemcell).with(
+          image,
+          instance_of(Bosh::AwsCloud::StemcellCloudProps),
+          nil,
+        ).and_return(ami_id)
         expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
         cloud.create_stemcell(image, stemcell_properties, env)
       end
 
       it "if no env is provided" do
+        expect(cloud).to receive(:create_ami_for_stemcell).with(
+          image,
+          instance_of(Bosh::AwsCloud::StemcellCloudProps),
+          nil,
+        ).and_return(ami_id)
         expect(Bosh::AwsCloud::TagManager).to_not receive(:create_tags)
         cloud.create_stemcell(image, stemcell_properties)
       end

--- a/src/bosh_aws_cpi/spec/unit/create_disk_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/create_disk_spec.rb
@@ -96,5 +96,23 @@ describe Bosh::AwsCloud::CloudV1 do
         end
       end
     end
+
+    describe 'tags' do
+      it 'passes tag_specifications when disk cloud_properties include tags' do
+        @cloud.create_disk(2048, { 'tags' => { 'env' => 'prod', 'owner' => 'bosh' } })
+
+        expect(@ec2.client).to have_received(:create_volume) do |params|
+          expect(params[:tag_specifications]).to eq([
+            {
+              resource_type: 'volume',
+              tags: [
+                { key: 'env', value: 'prod' },
+                { key: 'owner', value: 'bosh' },
+              ],
+            },
+          ])
+        end
+      end
+    end
   end
 end

--- a/src/bosh_aws_cpi/spec/unit/create_stemcell_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/create_stemcell_spec.rb
@@ -226,7 +226,7 @@ describe Bosh::AwsCloud::CloudV1 do
         expect(Bosh::AwsCloud::BlockDeviceManager).to receive(:device_path).with("/dev/sdh", instance.instance_type, volume.id).and_return("/dev/sdh")
         expect(Bosh::AwsCloud::BlockDeviceManager).to receive(:block_device_ready?).with("/dev/sdh").and_return("/dev/xvdh")
 
-        expect(creator).to receive(:create).with(volume, "/dev/xvdh", "/tmp/foo").and_return(stemcell)
+        expect(creator).to receive(:create).with(volume, "/dev/xvdh", "/tmp/foo", nil).and_return(stemcell)
 
         expect(volume_manager).to receive(:detach_ebs_volume).with(instance, volume, true)
         expect(volume_manager).to receive(:delete_ebs_volume).with(volume)
@@ -260,7 +260,7 @@ describe Bosh::AwsCloud::CloudV1 do
           expect(Bosh::AwsCloud::BlockDeviceManager).to receive(:block_device_ready?).with("/dev/sdh").and_return("/dev/xvdh")
 
           allow(creator).to receive(:create)
-          expect(creator).to receive(:create).with(volume, "/dev/xvdh", "/tmp/foo").and_return(stemcell)
+          expect(creator).to receive(:create).with(volume, "/dev/xvdh", "/tmp/foo", nil).and_return(stemcell)
 
           expect(volume_manager).to receive(:detach_ebs_volume).with(instance, volume, true)
           expect(volume_manager).to receive(:delete_ebs_volume).with(volume)
@@ -313,7 +313,7 @@ describe Bosh::AwsCloud::CloudV1 do
             expect(Bosh::AwsCloud::BlockDeviceManager).to receive(:device_path).with("/dev/sdh", instance.instance_type, volume.id).and_return("/dev/sdh")
             expect(Bosh::AwsCloud::BlockDeviceManager).to receive(:block_device_ready?).with("/dev/sdh").and_return("/dev/xvdh")
 
-            expect(creator).to receive(:create).with(volume, "/dev/xvdh", "/tmp/foo").and_return(stemcell)
+            expect(creator).to receive(:create).with(volume, "/dev/xvdh", "/tmp/foo", nil).and_return(stemcell)
 
             expect(volume_manager).to receive(:detach_ebs_volume).with(instance, volume, true)
             expect(volume_manager).to receive(:delete_ebs_volume).with(volume)
@@ -363,7 +363,7 @@ describe Bosh::AwsCloud::CloudV1 do
             expect(Bosh::AwsCloud::BlockDeviceManager).to receive(:device_path).with("/dev/sdh", instance.instance_type, volume.id).and_return("/dev/sdh")
             expect(Bosh::AwsCloud::BlockDeviceManager).to receive(:block_device_ready?).with("/dev/sdh").and_return("/dev/xvdh")
 
-            expect(creator).to receive(:create).with(volume, "/dev/xvdh", "/tmp/foo").and_return(stemcell)
+            expect(creator).to receive(:create).with(volume, "/dev/xvdh", "/tmp/foo", nil).and_return(stemcell)
 
             expect(volume_manager).to receive(:detach_ebs_volume).with(instance, volume, true)
             expect(volume_manager).to receive(:delete_ebs_volume).with(volume)
@@ -395,7 +395,7 @@ describe Bosh::AwsCloud::CloudV1 do
           expect(Bosh::AwsCloud::BlockDeviceManager).to receive(:device_path).with("/dev/sdh", instance.instance_type, volume.id).and_return("/dev/sdh")
           expect(Bosh::AwsCloud::BlockDeviceManager).to receive(:block_device_ready?).with("/dev/sdh").and_return("/dev/xvdh")
 
-          expect(creator).to receive(:create).with(volume, "/dev/xvdh", "/tmp/foo").and_return(stemcell)
+          expect(creator).to receive(:create).with(volume, "/dev/xvdh", "/tmp/foo", nil).and_return(stemcell)
 
           expect(volume_manager).to receive(:detach_ebs_volume).with(instance, volume, true)
           expect(volume_manager).to receive(:delete_ebs_volume).with(volume)

--- a/src/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
@@ -100,7 +100,7 @@ module Bosh::AwsCloud
           .with(ec2, logger)
           .and_return(network_interface_manager)
         allow(network_interface_manager).to receive(:create_network_interfaces)
-          .with(networks_cloud_props, vm_cloud_props, default_options)
+          .with(networks_cloud_props, vm_cloud_props, default_options, tags)
           .and_return(network_interfaces)
         allow(network_interface_manager).to receive(:set_delete_on_termination_for_network_interfaces).with(network_interfaces)
 
@@ -193,7 +193,7 @@ module Bosh::AwsCloud
         allow(aws_client).to receive(:run_instances).and_return('run-instances-response')
 
         expect(network_interface_manager).to receive(:create_network_interfaces)
-          .with(networks_cloud_props, vm_cloud_props, default_options)
+          .with(networks_cloud_props, vm_cloud_props, default_options, tags)
           .and_return(network_interfaces)
 
         instance_manager.create(

--- a/src/bosh_aws_cpi/spec/unit/instance_param_mapper_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/instance_param_mapper_spec.rb
@@ -509,14 +509,18 @@ module Bosh::AwsCloud
 
       describe 'tags' do
         context 'when tags are supplied' do
-          it 'constructs tag specification' do
+          it 'constructs tag specifications for instance and volume (RunInstances)' do
             instance_param_mapper.manifest_params = {
               vm_type: vm_cloud_props,
               tags: { 'tag' => 'tag_value' }
             }
-            expect(instance_param_mapper.instance_params(fake_nic_configuration)[:tag_specifications]).to_not be_nil
-            expect(instance_param_mapper.instance_params(fake_nic_configuration)[:tag_specifications][0][:tags]).to eq([{key: 'tag', value: 'tag_value'}])
-            expect(instance_param_mapper.instance_params(fake_nic_configuration)[:tag_specifications][0][:resource_type]).to eq('instance')
+            tag_specs = instance_param_mapper.instance_params(fake_nic_configuration)[:tag_specifications]
+            expect(tag_specs).to_not be_nil
+            expect(tag_specs.length).to eq(2)
+            expect(tag_specs[0][:resource_type]).to eq('instance')
+            expect(tag_specs[0][:tags]).to eq([{ key: 'tag', value: 'tag_value' }])
+            expect(tag_specs[1][:resource_type]).to eq('volume')
+            expect(tag_specs[1][:tags]).to eq([{ key: 'tag', value: 'tag_value' }])
           end
         end
       end

--- a/src/bosh_aws_cpi/spec/unit/network_interface_manager_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/network_interface_manager_spec.rb
@@ -77,6 +77,27 @@ module Bosh::AwsCloud
           expect(network_interfaces.first).to eq(network_interface)
         end
 
+        it 'includes tag_specifications when tags are provided' do
+          director_tags = { 'env' => 'prod' }
+          expected_with_tags = expected_create_ni_params.merge(
+            tag_specifications: [
+              {
+                resource_type: 'network-interface',
+                tags: [{ key: 'env', value: 'prod' }],
+              },
+            ]
+          )
+          expect(ec2_client).to receive(:create_network_interface).with(expected_with_tags).and_return(create_network_interface_response)
+
+          network_interfaces = network_interface_manager.create_network_interfaces(
+            networks_cloud_props,
+            vm_cloud_props,
+            default_security_groups,
+            director_tags
+          )
+          expect(network_interfaces.size).to eq(1)
+        end
+
         it 'retries the creation of one network interface if one network is defined and the address is currently in use' do
           allow(network_interface_manager).to receive(:network_interface_create_wait_time).and_return(0)
 

--- a/src/bosh_aws_cpi/spec/unit/snapshot_disk_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/snapshot_disk_spec.rb
@@ -20,33 +20,26 @@ describe Bosh::AwsCloud::CloudV1 do
     it 'should take a snapshot of a disk' do
       cloud = mock_cloud do |ec2|
         expect(ec2).to receive(:volume).with('vol-xxxxxxxx').and_return(volume)
+        expect(volume).to receive(:attachments).and_return([attachment])
+        expect(volume).to receive(:create_snapshot) do |args|
+          expect(args[:description]).to eq('deployment/job/0/sdf')
+          expect(args[:tag_specifications].length).to eq(1)
+          expect(args[:tag_specifications][0][:resource_type]).to eq('snapshot')
+          expect(args[:tag_specifications][0][:tags]).to include(
+            { key: 'agent_id', value: 'agent' },
+            { key: 'Name', value: 'deployment/job/0/sdf' }
+          )
+          snapshot
+        end
       end
 
-      expect(volume).to receive(:attachments).and_return([attachment])
-      expect(volume).to receive(:create_snapshot).with(description: 'deployment/job/0/sdf').and_return(snapshot)
-
       expect(Bosh::AwsCloud::ResourceWait).to receive(:for_snapshot).with(snapshot: snapshot, state: 'completed')
-
-      expect(Bosh::AwsCloud::TagManager).to receive(:create_tags).with(snapshot,
-        'agent_id' => 'agent',
-        'instance_id' => 'instance',
-        'director_uuid' => '6d06b0cc-2c08-43c5-95be-f1b2dd247e18',
-        'deployment'=> 'deployment',
-        'device' => '/dev/sdf',
-        'director' => 'Test Director',
-        'instance_index'=> '0',
-        'instance_name'=> 'job/instance',
-        'Name' => 'deployment/job/0/sdf'
-      )
 
       cloud.snapshot_disk('vol-xxxxxxxx', metadata)
     end
 
     it 'handles string keys in metadata' do
-      cloud = mock_cloud do |ec2|
-        expect(ec2).to receive(:volume).with('vol-xxxxxxxx').and_return(volume)
-      end
-      metadata = {
+      metadata_str = {
         'agent_id' => 'agent',
         'instance_id' => 'instance',
         'director_name' => 'Test Director',
@@ -56,49 +49,37 @@ describe Bosh::AwsCloud::CloudV1 do
         'index' => '0'
       }
 
-      allow(volume).to receive(:attachments).and_return([attachment])
-      allow(volume).to receive(:create_snapshot).with(description: 'deployment/job/0/sdf').and_return(snapshot)
+      cloud = mock_cloud do |ec2|
+        expect(ec2).to receive(:volume).with('vol-xxxxxxxx').and_return(volume)
+        allow(volume).to receive(:attachments).and_return([attachment])
+        expect(volume).to receive(:create_snapshot) do |args|
+          expect(args[:description]).to eq('deployment/job/0/sdf')
+          expect(args[:tag_specifications][0][:resource_type]).to eq('snapshot')
+          snapshot
+        end
+      end
 
       allow(Bosh::AwsCloud::ResourceWait).to receive(:for_snapshot).with(snapshot: snapshot, state: 'completed')
 
-      expect(Bosh::AwsCloud::TagManager).to receive(:create_tags).with(
-        snapshot,
-        'agent_id' => 'agent',
-        'instance_id' => 'instance',
-        'director_uuid' => '6d06b0cc-2c08-43c5-95be-f1b2dd247e18',
-        'deployment' => 'deployment',
-        'device' => '/dev/sdf',
-        'director' => 'Test Director',
-        'instance_index' => '0',
-        'instance_name' => 'job/instance',
-        'Name' => 'deployment/job/0/sdf'
-      )
-
-      cloud.snapshot_disk('vol-xxxxxxxx', metadata)
+      cloud.snapshot_disk('vol-xxxxxxxx', metadata_str)
     end
 
     it 'should take a snapshot of a disk not attached to any instance' do
       cloud = mock_cloud do |ec2|
         expect(ec2).to receive(:volume).with('vol-xxxxxxxx').and_return(volume)
+        expect(volume).to receive(:attachments).and_return([])
+        expect(volume).to receive(:create_snapshot) do |args|
+          expect(args[:description]).to eq('deployment/job/0')
+          expect(args[:tag_specifications][0][:resource_type]).to eq('snapshot')
+          expect(args[:tag_specifications][0][:tags]).to include(
+            { key: 'Name', value: 'deployment/job/0' }
+          )
+          snapshot
+        end
       end
-
-      expect(volume).to receive(:attachments).and_return([])
-      expect(volume).to receive(:create_snapshot).with(description: 'deployment/job/0').and_return(snapshot)
 
       expect(Bosh::AwsCloud::ResourceWait).to receive(:for_snapshot).with(
         snapshot: snapshot, state: 'completed'
-      )
-
-      expect(Bosh::AwsCloud::TagManager).to receive(:create_tags).with(
-        snapshot,
-        'agent_id' => 'agent',
-        'instance_id' => 'instance',
-        'director_uuid' => '6d06b0cc-2c08-43c5-95be-f1b2dd247e18',
-        'deployment' => 'deployment',
-        'director' => 'Test Director',
-        'instance_index' => '0',
-        'instance_name' => 'job/instance',
-        'Name' => 'deployment/job/0'
       )
 
       cloud.snapshot_disk('vol-xxxxxxxx', metadata)

--- a/src/bosh_aws_cpi/spec/unit/stemcell_creator_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/stemcell_creator_spec.rb
@@ -24,10 +24,15 @@ module Bosh::AwsCloud
       allow(Bosh::AwsCloud::AKIPicker).to receive(:new).and_return(double('aki', :pick => 'aki-xxxxxxxx'))
     end
 
-    let(:volume) { instance_double(Aws::EC2::Volume) }
+    let(:volume) { instance_double(Aws::EC2::Volume, id: 'vol-stemcell') }
     let(:snapshot) { instance_double(Aws::EC2::Snapshot, :id => 'snap-xxxxxxxx') }
     let(:image_id) {'ami-a1b2c3d4'}
     let(:image) { instance_double(Aws::EC2::Image, :id => image_id) }
+    let(:ec2_client) { instance_double(Aws::EC2::Client) }
+
+    before do
+      allow(ec2_resource).to receive(:client).and_return(ec2_client)
+    end
 
     it 'should create a real stemcell' do
       creator = described_class.new(ec2_resource, stemcell_cloud_props)
@@ -35,11 +40,17 @@ module Bosh::AwsCloud
       allow(Bosh::AwsCloud::ResourceWait).to receive(:for_image).with(image: image, state: 'available')
       allow(SecureRandom).to receive(:uuid).and_return('fake-uuid')
       allow(ec2_resource).to receive(:images).and_return(double(Aws::Resources::Collection, first: image))
-      allow(ec2_resource).to receive_message_chain(:client, :register_image).and_return(double('object', :image_id => image_id))
+      expect(volume).to receive(:create_snapshot).with(tag_specifications: []).and_return(snapshot)
+      expect(ec2_client).to receive(:register_image) do |params|
+        expect(params[:tag_specifications]).not_to be_nil
+        expect(params[:tag_specifications].first[:resource_type]).to eq('image')
+        expect(params[:tag_specifications].first[:tags]).to include(
+          { key: 'Name', value: 'stemcell-name 0.7.0' }
+        )
+        double('object', image_id: image_id)
+      end
 
       expect(creator).to receive(:copy_root_image)
-      expect(volume).to receive(:create_snapshot).and_return(snapshot)
-      expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(image, 'Name', 'stemcell-name 0.7.0')
 
       creator.create(volume, 'device_path', '/path/to/image')
     end
@@ -71,6 +82,10 @@ module Bosh::AwsCloud
               :virtual_name => 'ephemeral0',
             },
           ])
+          expect(params[:tag_specifications].first[:resource_type]).to eq('image')
+          expect(params[:tag_specifications].first[:tags]).to include(
+            { key: 'Name', value: 'stemcell-name 0.7.0' }
+          )
         end
       end
 
@@ -113,6 +128,10 @@ module Bosh::AwsCloud
           ])
           expect(params[:virtualization_type]).to eq('hvm')
           expect(params[:ena_support]).to be(true)
+          expect(params[:tag_specifications].first[:resource_type]).to eq('image')
+          expect(params[:tag_specifications].first[:tags]).to include(
+            { key: 'Name', value: 'stemcell-name 0.7.0' }
+          )
         end
       end
     end

--- a/src/bosh_aws_cpi/spec/unit/tag_manager_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/tag_manager_spec.rb
@@ -91,4 +91,27 @@ describe Bosh::AwsCloud::TagManager do
     expect(instance).not_to receive(:create_tags)
     Bosh::AwsCloud::TagManager.tag(instance, 'key', nil)
   end
+
+  describe '.tag_specifications_for_resources' do
+    it 'returns empty array for nil or empty tags' do
+      expect(described_class.tag_specifications_for_resources(nil, ['instance'])).to eq([])
+      expect(described_class.tag_specifications_for_resources({}, ['instance'])).to eq([])
+    end
+
+    it 'builds one entry per resource type with formatted tags' do
+      tags = { 'k' => 'v', 'empty' => nil }
+      specs = described_class.tag_specifications_for_resources(tags, %w[instance volume])
+      expect(specs.length).to eq(2)
+      expect(specs[0][:resource_type]).to eq('instance')
+      expect(specs[0][:tags]).to eq([{ key: 'k', value: 'v' }])
+      expect(specs[1][:resource_type]).to eq('volume')
+      expect(specs[1][:tags]).to eq([{ key: 'k', value: 'v' }])
+    end
+
+    it 'accepts a single resource type string' do
+      specs = described_class.tag_specifications_for_resources({ 'a' => 'b' }, 'snapshot')
+      expect(specs.length).to eq(1)
+      expect(specs[0][:resource_type]).to eq('snapshot')
+    end
+  end
 end

--- a/src/bosh_aws_cpi/spec/unit/volume_properties_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/volume_properties_spec.rb
@@ -12,7 +12,7 @@ module Bosh::AwsCloud
         encrypted: true,
         kms_key_arn: 'my_fake_kms_arn',
         root_device_name: '/dev/sda',
-        tags: [{name: "foo", value: "bar"}]
+        tags: [{ key: 'foo', value: 'bar' }]
       }
     end
     describe '#ephemeral_disk_config' do
@@ -78,7 +78,7 @@ module Bosh::AwsCloud
             kms_key_id: 'my_fake_kms_arn',
             tag_specifications: [{
               resource_type: 'volume',
-              tags: [{name: "foo", value: "bar"}]
+              tags: [{ key: 'foo', value: 'bar' }]
             }]
           )
         end


### PR DESCRIPTION
The existing code would add tags with a separate CreateTags call after creation. However, in environments with policy requiring tags on creation, users will have issues.

TODO: There's an open question on how to handle spot instances. I believe the current pattern we use does not support passing tags in (we explicitly remove them in this case: 12980a11c019bb4a5271b3b3bdf71169c1b213e5). I don't really know much about how this feature is used generally. But from what I've learned so far, it seems like we can now use RunInstances the same way with some extra options to handle spot instances, and allow us to pass tags. Still investigating