### PR TITLE
fix: move inline comments out of bosh deploy backslash continuation

### DIFF
--- a/ci/tasks/run-e2e.sh
+++ b/ci/tasks/run-e2e.sh
@@ -34,10 +34,11 @@ time bosh -n ucc \
   bosh-aws-cpi-release/ci/assets/e2e-test-release/cloud-config.yml
 
 # BOSH DEPLOY
-time bosh -n deploy -d e2e-test \
-  -v "stemcell_name=${stemcell_name}" \
+# No comments allowed in bash with slash continuation
   # -v "heavy_stemcell_name=${heavy_stemcell_name}" \
   # -v "encrypted_heavy_stemcell_ami_id=${encrypted_heavy_stemcell_ami_id}" \
+time bosh -n deploy -d e2e-test \
+  -v "stemcell_name=${stemcell_name}" \
   -v "aws_kms_key_arn=${BOSH_AWS_KMS_KEY_ARN}" \
   -l environment/metadata \
   bosh-aws-cpi-release/ci/assets/e2e-test-release/manifest.yml


### PR DESCRIPTION
## Summary

- Inline `# -v` comments inside a backslash-continued `bosh deploy` command caused bash to treat the trailing `\` as part of the comment, breaking the continuation chain
- This meant `bosh deploy` ran without the manifest `PATH` argument, failing with `the required argument PATH was not provided`
- Fixed by moving the commented-out `-v` args above the `bosh deploy` command

## Test plan

- [ ] Retrigger the `end-2-end` job in the pipeline to verify the deploy step no longer fails with a missing PATH error

Made with [Cursor](https://cursor.com)