### PR TITLE
ci: keep provider cert when setting up director

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -146,7 +146,6 @@ jobs:
         OPTIONAL_OPS_FILE: |
           -o pipelines/shared/assets/ops/remove-hm.yml
           -o bosh-deployment/external-ip-with-registry-not-recommended.yml
-          -o pipelines/shared/assets/ops/remove-provider-cert.yml
     - do:
       - <<: *deploy-director
       - <<: *run-bats
@@ -196,7 +195,6 @@ jobs:
         <<: *prepare-director-params
         OPTIONAL_OPS_FILE: |
           -o bosh-deployment/external-ip-with-registry-not-recommended.yml
-          -o pipelines/shared/assets/ops/remove-provider-cert.yml
           -o pipelines/aws/assets/ops/iam-instance-profile-ops-file.yml
     - do:
       - <<: *deploy-director


### PR DESCRIPTION
(already flown)

I believe as part of https://github.com/cloudfoundry/bosh-cli/pull/725 (bosh-cli v7.10.4), the cert handling changed in the CLI

from what AI tells me, in the CLI code now, when cloud_provider.cert is absent (because remove-provider-cert.yml removes it), the certPool is nil → the client falls back to verifying against system roots. The BOSH bootstrap agent's cert is signed by the private default_ca, which is not in the system root store → x509: certificate signed by unknown authority.

this shows up like this:
https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-aws-cpi/jobs/bats/builds/223
https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-aws-cpi/jobs/end-2-end/builds/146