### PR TITLE
docs: add ec2:DescribeInstanceTypes to baseline IAM policy

### DIFF
--- a/docs/iam-policy.json
+++ b/docs/iam-policy.json
@@ -12,6 +12,7 @@
                 "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeImages",
                 "ec2:DescribeInstances",
+                "ec2:DescribeInstanceTypes",
                 "ec2:DescribeRegions",
                 "ec2:DescribeSecurityGroups",
                 "ec2:DescribeSubnets",


### PR DESCRIPTION
PR #196 introduced DescribeInstanceTypes calls to determine NVMe path requirements.

The IAM user in AWS must be updated with the new permission.