### PR TITLE
ci: add missing params to e2e task

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -32,6 +32,8 @@ shared:
   image: bosh-integration-image
   params:
     BOSH_AWS_KMS_KEY_ARN: ((arn_keys.aws_kms_key_arn))
+    AWS_ACCESS_KEY_ID: ((aws-cpi-e2e-tests.username))
+    AWS_SECRET_ACCESS_KEY: ((aws-cpi-e2e-tests.password))
 
 - &ensure-terminated
   task: ensure-terminated


### PR DESCRIPTION
previous changes extended the e2e tests and need these

should address this failure: https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-aws-cpi/jobs/end-2-end/builds/161

already flown and testing out here: https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-aws-cpi/jobs/end-2-end/builds/162