### PR TITLE
Fix unit test regexes for Ruby 3.4 Hash#inspect format change

### DIFF
--- a/src/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
+++ b/src/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
@@ -230,15 +230,15 @@ module Bosh::AwsCloud
         end
 
         it '`user_data` when creating an instance' do
-          expect(logger).to have_received(:info).with(/"user_data"=>"<redacted>"/)
+          expect(logger).to have_received(:info).with(/"user_data" ?=> ?"<redacted>"/)
         end
 
         it '`defaults.access_key_id` when creating an instance' do
-          expect(logger).to have_received(:info).with(/"access_key_id"=>"<redacted>"/)
+          expect(logger).to have_received(:info).with(/"access_key_id" ?=> ?"<redacted>"/)
         end
 
         it '`defaults.secret_access_key` when creating an instance' do
-          expect(logger).to have_received(:info).with(/"secret_access_key"=>"<redacted>"/)
+          expect(logger).to have_received(:info).with(/"secret_access_key" ?=> ?"<redacted>"/)
         end
       end
 


### PR DESCRIPTION
Ruby 3.4 changed Hash#inspect to add spaces around => e.g. "key" => "value" instead of "key"=>"value". Update the three log assertion regexes in instance_manager_spec to tolerate optional spaces so they pass on both Ruby 3.3 and 3.4.
Confirmed this unblocks the bump-deps pipeline.

Continuation of #219 