### PR TITLE
The CPI no longer calls RequestSpotInstances

### DIFF
--- a/ci/assets/e2e-test-release/enforce-tags-policy.json
+++ b/ci/assets/e2e-test-release/enforce-tags-policy.json
@@ -6,13 +6,11 @@
         "Effect": "Deny",
         "Action": [
           "ec2:RunInstances",
-          "ec2:RequestSpotInstances",
           "ec2:CreateVolume"
         ],
         "Resource": [
           "arn:aws:ec2:*:*:instance/*",
-          "arn:aws:ec2:*:*:volume/*",
-          "arn:aws:ec2:*:*:spot-instances-request/*"
+          "arn:aws:ec2:*:*:volume/*"
         ],
         "Condition": {
           "Null": {


### PR DESCRIPTION
Removed vestigial spot instance API policy