### PR TITLE
build(deps): add ostruct gem for Ruby 4.0 compatibility

### DIFF
--- a/src/bosh_aws_cpi/Gemfile
+++ b/src/bosh_aws_cpi/Gemfile
@@ -7,6 +7,7 @@ gem 'aws-sdk-elasticloadbalancingv2'
 gem 'aws-sdk-iam'
 
 gem 'rexml'
+gem 'ostruct'
 gem 'bosh_common'
 gem 'bosh_cpi'
 

--- a/src/bosh_aws_cpi/Gemfile.lock
+++ b/src/bosh_aws_cpi/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
     multi_json (1.21.1)
     mutex_m (0.3.0)
     openssl (4.0.2)
+    ostruct (0.6.3)
     parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -135,6 +136,7 @@ DEPENDENCIES
   aws-sdk-iam
   bosh_common
   bosh_cpi
+  ostruct
   pry-byebug
   rake
   rexml

--- a/src/bosh_aws_cpi/vendor/package/ostruct-0.6.3.gem
+++ b/src/bosh_aws_cpi/vendor/package/ostruct-0.6.3.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
+size 12800


### PR DESCRIPTION
## Summary

- Adds `ostruct` gem (v0.6.3) as an explicit dependency in `Gemfile`, `Gemfile.lock`, and the vendored gem cache
- Fixes the `bump-bosh-packages` CI job failure ([build #113](https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-aws-cpi/jobs/bump-bosh-packages/builds/113)) caused by Ruby 4.0 removing `ostruct` from default gems

## Root Cause

In Ruby 4.0, `ostruct` was removed from the default gems. The spec file `spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb` and the production binaries `bin/aws_cpi` and `bin/bosh_aws_console` all `require 'ostruct'`, which fails at load time on Ruby 4.0+:

```
LoadError: cannot load such file -- ostruct
```

## Fix

Declares `ostruct` as an explicit gem dependency. The `ostruct` gem (>= 2.5.0) is a maintained extraction of the stdlib class and works on Ruby 2.x, 3.x, and 4.x — so this change is backward-compatible with the current Ruby 3.3-based CPI runtime.

## Test plan

- [ ] Verify `bump-bosh-packages` CI job passes with the updated Ruby 3.4 and 4.0 packages
- [ ] Verify the CPI unit specs pass locally against the current Ruby version