### PR TITLE
Fix command injection vulnerability in stemcell-copy

### DIFF
--- a/src/bosh_aws_cpi/bin/stemcell-copy
+++ b/src/bosh_aws_cpi/bin/stemcell-copy
@@ -41,4 +41,4 @@ if [[ "${OUTPUT_REAL}" == "${ROOT_DEVICE}" || \
 fi
 
 # copy image to block device with 1 MB block size
-tar -xzf ${IMAGE} -O root.img | dd bs=1M of=${OUTPUT_PATH}
+tar -xzf "${IMAGE}" -O root.img | dd bs=1M of="${OUTPUT_PATH}"


### PR DESCRIPTION
## Summary
* Quotes the `$IMAGE` and `$OUTPUT_PATH` variables in `src/bosh_aws_cpi/bin/stemcell-copy` to prevent command injection.

## Test plan
* Ran unit tests for `stemcell_creator_spec.rb` which verify the stemcell copying logic.

Made with [Cursor](https://cursor.com)